### PR TITLE
Feature/U-02 #62 : logout, jwt token refresh, @AuthenticationPrincipal 이용

### DIFF
--- a/backend/src/main/java/com/frend/planit/domain/auth/client/GoogleOauthClient.java
+++ b/backend/src/main/java/com/frend/planit/domain/auth/client/GoogleOauthClient.java
@@ -1,7 +1,7 @@
-package com.frend.planit.domain.user.client;
+package com.frend.planit.domain.auth.client;
 
-import com.frend.planit.domain.user.dto.response.GoogleTokenResponse;
-import com.frend.planit.domain.user.dto.response.GoogleUserInfoResponse;
+import com.frend.planit.domain.auth.dto.response.GoogleTokenResponse;
+import com.frend.planit.domain.auth.dto.response.GoogleUserInfoResponse;
 import com.frend.planit.domain.user.enums.SocialType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/backend/src/main/java/com/frend/planit/domain/auth/client/OAuthClient.java
+++ b/backend/src/main/java/com/frend/planit/domain/auth/client/OAuthClient.java
@@ -1,7 +1,7 @@
-package com.frend.planit.domain.user.client;
+package com.frend.planit.domain.auth.client;
 
-import com.frend.planit.domain.user.dto.response.GoogleTokenResponse;
-import com.frend.planit.domain.user.dto.response.GoogleUserInfoResponse;
+import com.frend.planit.domain.auth.dto.response.GoogleTokenResponse;
+import com.frend.planit.domain.auth.dto.response.GoogleUserInfoResponse;
 import com.frend.planit.domain.user.enums.SocialType;
 
 /**

--- a/backend/src/main/java/com/frend/planit/domain/auth/client/OAuthClientFactory.java
+++ b/backend/src/main/java/com/frend/planit/domain/auth/client/OAuthClientFactory.java
@@ -1,4 +1,4 @@
-package com.frend.planit.domain.user.client;
+package com.frend.planit.domain.auth.client;
 
 import com.frend.planit.domain.user.enums.SocialType;
 import com.frend.planit.global.exception.ServiceException;

--- a/backend/src/main/java/com/frend/planit/domain/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/frend/planit/domain/auth/controller/AuthController.java
@@ -1,8 +1,8 @@
-package com.frend.planit.domain.user.controller;
+package com.frend.planit.domain.auth.controller;
 
-import com.frend.planit.domain.user.dto.request.SocialLoginRequest;
-import com.frend.planit.domain.user.dto.response.SocialLoginResponse;
-import com.frend.planit.domain.user.service.UserService;
+import com.frend.planit.domain.auth.dto.request.SocialLoginRequest;
+import com.frend.planit.domain.auth.dto.response.SocialLoginResponse;
+import com.frend.planit.domain.auth.service.AuthService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class AuthController {
 
-    private final UserService userService;
+    private final AuthService authService;
 
     /**
      * 소셜 로그인 (Google, Kakao, Naver)
@@ -25,7 +25,7 @@ public class AuthController {
     public ResponseEntity<SocialLoginResponse> socialLogin(
             @RequestBody @Valid SocialLoginRequest request
     ) {
-        SocialLoginResponse response = userService.loginOrRegister(request);
+        SocialLoginResponse response = authService.loginOrRegister(request);
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/com/frend/planit/domain/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/frend/planit/domain/auth/controller/AuthController.java
@@ -5,6 +5,9 @@ import com.frend.planit.domain.auth.dto.request.TokenRefreshRequest;
 import com.frend.planit.domain.auth.dto.response.SocialLoginResponse;
 import com.frend.planit.domain.auth.dto.response.TokenRefreshResponse;
 import com.frend.planit.domain.auth.service.AuthService;
+import com.frend.planit.global.exception.ServiceException;
+import com.frend.planit.global.response.ErrorType;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -31,13 +34,25 @@ public class AuthController {
         return ResponseEntity.ok(response);
     }
 
-    // Access Token 재발급 API, 클라이언트로부터 전달받은 Refresh Token이 유효할 경우,
-    // 새로운 Access Token을 발급하여 반환
+    // Access Token 재발급 API, 클라이언트로부터 전달받은 Refresh Token이 유효할 경우, 새로운 Access Token을 발급
     @PostMapping("/token/refresh")
     public ResponseEntity<TokenRefreshResponse> refreshAccessToken(
             @RequestBody @Valid TokenRefreshRequest request
     ) {
         TokenRefreshResponse response = authService.refreshAccessToken(request.getRefreshToken());
         return ResponseEntity.ok(response);
+    }
+
+    //토큰 제거하면서 로그아웃
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(HttpServletRequest request) {
+        String bearer = request.getHeader("Authorization");
+        if (bearer == null || !bearer.startsWith("Bearer ")) {
+            throw new ServiceException(ErrorType.UNAUTHORIZED);
+        }
+
+        String accessToken = bearer.substring(7);
+        authService.logout(accessToken);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/frend/planit/domain/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/frend/planit/domain/auth/controller/AuthController.java
@@ -1,7 +1,9 @@
 package com.frend.planit.domain.auth.controller;
 
 import com.frend.planit.domain.auth.dto.request.SocialLoginRequest;
+import com.frend.planit.domain.auth.dto.request.TokenRefreshRequest;
 import com.frend.planit.domain.auth.dto.response.SocialLoginResponse;
+import com.frend.planit.domain.auth.dto.response.TokenRefreshResponse;
 import com.frend.planit.domain.auth.service.AuthService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +28,16 @@ public class AuthController {
             @RequestBody @Valid SocialLoginRequest request
     ) {
         SocialLoginResponse response = authService.loginOrRegister(request);
+        return ResponseEntity.ok(response);
+    }
+
+    // Access Token 재발급 API, 클라이언트로부터 전달받은 Refresh Token이 유효할 경우,
+    // 새로운 Access Token을 발급하여 반환
+    @PostMapping("/token/refresh")
+    public ResponseEntity<TokenRefreshResponse> refreshAccessToken(
+            @RequestBody @Valid TokenRefreshRequest request
+    ) {
+        TokenRefreshResponse response = authService.refreshAccessToken(request.getRefreshToken());
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/com/frend/planit/domain/auth/dto/request/SocialLoginRequest.java
+++ b/backend/src/main/java/com/frend/planit/domain/auth/dto/request/SocialLoginRequest.java
@@ -1,4 +1,4 @@
-package com.frend.planit.domain.user.dto.request;
+package com.frend.planit.domain.auth.dto.request;
 
 import com.frend.planit.domain.user.enums.SocialType;
 import lombok.AllArgsConstructor;

--- a/backend/src/main/java/com/frend/planit/domain/auth/dto/request/TokenRefreshRequest.java
+++ b/backend/src/main/java/com/frend/planit/domain/auth/dto/request/TokenRefreshRequest.java
@@ -1,8 +1,10 @@
 package com.frend.planit.domain.auth.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+@AllArgsConstructor
 @Getter
 public class TokenRefreshRequest {
 

--- a/backend/src/main/java/com/frend/planit/domain/auth/dto/request/TokenRefreshRequest.java
+++ b/backend/src/main/java/com/frend/planit/domain/auth/dto/request/TokenRefreshRequest.java
@@ -1,0 +1,11 @@
+package com.frend.planit.domain.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class TokenRefreshRequest {
+
+    @NotBlank(message = "리프레시 토큰은 필수입니다.")
+    private String refreshToken;
+}

--- a/backend/src/main/java/com/frend/planit/domain/auth/dto/response/GoogleTokenResponse.java
+++ b/backend/src/main/java/com/frend/planit/domain/auth/dto/response/GoogleTokenResponse.java
@@ -1,4 +1,4 @@
-package com.frend.planit.domain.user.dto.response;
+package com.frend.planit.domain.auth.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;

--- a/backend/src/main/java/com/frend/planit/domain/auth/dto/response/GoogleUserInfoResponse.java
+++ b/backend/src/main/java/com/frend/planit/domain/auth/dto/response/GoogleUserInfoResponse.java
@@ -1,4 +1,4 @@
-package com.frend.planit.domain.user.dto.response;
+package com.frend.planit.domain.auth.dto.response;
 
 import lombok.Data;
 

--- a/backend/src/main/java/com/frend/planit/domain/auth/dto/response/SocialLoginResponse.java
+++ b/backend/src/main/java/com/frend/planit/domain/auth/dto/response/SocialLoginResponse.java
@@ -1,4 +1,4 @@
-package com.frend.planit.domain.user.dto.response;
+package com.frend.planit.domain.auth.dto.response;
 
 import com.frend.planit.domain.user.enums.UserStatus;
 import lombok.AllArgsConstructor;

--- a/backend/src/main/java/com/frend/planit/domain/auth/dto/response/TokenRefreshResponse.java
+++ b/backend/src/main/java/com/frend/planit/domain/auth/dto/response/TokenRefreshResponse.java
@@ -8,4 +8,11 @@ import lombok.Getter;
 public class TokenRefreshResponse {
 
     private String accessToken;
+    private String refreshToken;
+
+    public TokenRefreshResponse(String accessToken, String refreshToken) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+
 }

--- a/backend/src/main/java/com/frend/planit/domain/auth/dto/response/TokenRefreshResponse.java
+++ b/backend/src/main/java/com/frend/planit/domain/auth/dto/response/TokenRefreshResponse.java
@@ -1,0 +1,11 @@
+package com.frend.planit.domain.auth.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TokenRefreshResponse {
+
+    private String accessToken;
+}

--- a/backend/src/main/java/com/frend/planit/domain/auth/dto/response/TokenRefreshResponse.java
+++ b/backend/src/main/java/com/frend/planit/domain/auth/dto/response/TokenRefreshResponse.java
@@ -10,9 +10,4 @@ public class TokenRefreshResponse {
     private String accessToken;
     private String refreshToken;
 
-    public TokenRefreshResponse(String accessToken, String refreshToken) {
-        this.accessToken = accessToken;
-        this.refreshToken = refreshToken;
-    }
-
 }

--- a/backend/src/main/java/com/frend/planit/domain/auth/service/AuthService.java
+++ b/backend/src/main/java/com/frend/planit/domain/auth/service/AuthService.java
@@ -6,9 +6,12 @@ import com.frend.planit.domain.auth.dto.request.SocialLoginRequest;
 import com.frend.planit.domain.auth.dto.response.GoogleTokenResponse;
 import com.frend.planit.domain.auth.dto.response.GoogleUserInfoResponse;
 import com.frend.planit.domain.auth.dto.response.SocialLoginResponse;
+import com.frend.planit.domain.auth.dto.response.TokenRefreshResponse;
 import com.frend.planit.domain.user.entity.User;
 import com.frend.planit.domain.user.mapper.UserMapper;
 import com.frend.planit.domain.user.repository.UserRepository;
+import com.frend.planit.global.exception.ServiceException;
+import com.frend.planit.global.response.ErrorType;
 import com.frend.planit.global.security.JwtTokenProvider;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
@@ -28,7 +31,6 @@ public class AuthService {
     /**
      * 소셜 로그인 또는 회원가입
      */
-
     public SocialLoginResponse loginOrRegister(SocialLoginRequest request) {
         OAuthClient client = oauthClientFactory.getClient(request.getSocialType());
 
@@ -55,5 +57,26 @@ public class AuthService {
         );
 
         return new SocialLoginResponse(accessToken, refreshToken, user.getStatus());
+    }
+
+    //Refresh Token을 검증하여 새로운 Access Token을 발급.
+    public TokenRefreshResponse refreshAccessToken(String refreshToken) {
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
+            throw new ServiceException(ErrorType.UNAUTHORIZED);
+        }
+        //refreshToken 값에서 userId 추출
+        Long userId = jwtTokenProvider.getUserIdFromToken(refreshToken);
+        String savedToken = refreshTokenRedisService.get(userId);
+
+        //Redis에 저장된 Refresh Token과 일치하는지 확인
+        if (!refreshToken.equals(savedToken)) {
+            throw new ServiceException(ErrorType.UNAUTHORIZED);
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ServiceException(ErrorType.COMMON_SERVER_ERROR));
+        //유효할 경우, 새로운 Access Token을 발급하여 반환
+        String newAccessToken = jwtTokenProvider.createAccessToken(user.getId(), user.getRole());
+        return new TokenRefreshResponse(newAccessToken);
     }
 }

--- a/backend/src/main/java/com/frend/planit/domain/auth/service/AuthService.java
+++ b/backend/src/main/java/com/frend/planit/domain/auth/service/AuthService.java
@@ -59,7 +59,9 @@ public class AuthService {
         return new SocialLoginResponse(accessToken, refreshToken, user.getStatus());
     }
 
-    //Refresh Token을 검증하여 새로운 Access Token을 발급.
+    /**
+     * Refresh Token을 검증하여 새로운 Access Token을 발급.
+     */
     public TokenRefreshResponse refreshAccessToken(String refreshToken) {
         if (!jwtTokenProvider.validateToken(refreshToken)) {
             throw new ServiceException(ErrorType.UNAUTHORIZED);
@@ -79,4 +81,18 @@ public class AuthService {
         String newAccessToken = jwtTokenProvider.createAccessToken(user.getId(), user.getRole());
         return new TokenRefreshResponse(newAccessToken);
     }
+
+    /**
+     * 로그아웃,, JWT에서 userId 추출, Redis에서 해당 user refreshToken 삭제
+     */
+    public void logout(String accessToken) {
+        if (!jwtTokenProvider.validateToken(accessToken)) {
+            throw new ServiceException(ErrorType.UNAUTHORIZED);
+        }
+
+        Long userId = jwtTokenProvider.getUserIdFromToken(accessToken);
+        refreshTokenRedisService.delete(userId);
+    }
+
+
 }

--- a/backend/src/main/java/com/frend/planit/domain/auth/service/AuthService.java
+++ b/backend/src/main/java/com/frend/planit/domain/auth/service/AuthService.java
@@ -1,0 +1,59 @@
+package com.frend.planit.domain.auth.service;
+
+import com.frend.planit.domain.auth.client.OAuthClient;
+import com.frend.planit.domain.auth.client.OAuthClientFactory;
+import com.frend.planit.domain.auth.dto.request.SocialLoginRequest;
+import com.frend.planit.domain.auth.dto.response.GoogleTokenResponse;
+import com.frend.planit.domain.auth.dto.response.GoogleUserInfoResponse;
+import com.frend.planit.domain.auth.dto.response.SocialLoginResponse;
+import com.frend.planit.domain.user.entity.User;
+import com.frend.planit.domain.user.mapper.UserMapper;
+import com.frend.planit.domain.user.repository.UserRepository;
+import com.frend.planit.global.security.JwtTokenProvider;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AuthService {
+
+    private final OAuthClientFactory oauthClientFactory;
+    private final UserRepository userRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenRedisService refreshTokenRedisService;
+
+    /**
+     * 소셜 로그인 또는 회원가입
+     */
+
+    public SocialLoginResponse loginOrRegister(SocialLoginRequest request) {
+        OAuthClient client = oauthClientFactory.getClient(request.getSocialType());
+
+        GoogleTokenResponse tokenResponse = client.getAccessToken(request.getCode());
+        GoogleUserInfoResponse userInfo = client.getUserInfo(tokenResponse.getAccessToken());
+
+        User user = userRepository.findBySocialIdAndSocialType(userInfo.getSub(),
+                        client.getSocialType())
+                .orElseGet(() ->
+                        userRepository.save(
+                                UserMapper.toEntity(userInfo, client.getSocialType())
+                        ));
+        // 마지막 로그인 시간 갱신
+        user.updateLastLoginAt(LocalDateTime.now());
+
+        // JWT 토큰 발급
+        String accessToken = jwtTokenProvider.createAccessToken(user.getId(), user.getRole());
+        String refreshToken = jwtTokenProvider.createRefreshToken(user.getId());
+
+        refreshTokenRedisService.save(
+                user.getId(),
+                refreshToken,
+                jwtTokenProvider.getRefreshTokenExpirationMs()
+        );
+
+        return new SocialLoginResponse(accessToken, refreshToken, user.getStatus());
+    }
+}

--- a/backend/src/main/java/com/frend/planit/domain/auth/service/RefreshTokenRedisService.java
+++ b/backend/src/main/java/com/frend/planit/domain/auth/service/RefreshTokenRedisService.java
@@ -1,0 +1,32 @@
+package com.frend.planit.domain.auth.service;
+
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenRedisService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    private static final String PREFIX = "RT:";
+
+    public void save(Long userId, String refreshToken, long expirationMs) {
+        String key = getKey(userId);
+        redisTemplate.opsForValue().set(key, refreshToken, Duration.ofMillis(expirationMs));
+    }
+
+    public String get(Long userId) {
+        return redisTemplate.opsForValue().get(getKey(userId));
+    }
+
+    public void delete(Long userId) {
+        redisTemplate.delete(getKey(userId));
+    }
+
+    private String getKey(Long userId) {
+        return PREFIX + userId;
+    }
+}

--- a/backend/src/main/java/com/frend/planit/domain/user/controller/AuthController.java
+++ b/backend/src/main/java/com/frend/planit/domain/user/controller/AuthController.java
@@ -1,0 +1,31 @@
+package com.frend.planit.domain.user.controller;
+
+import com.frend.planit.domain.user.dto.request.SocialLoginRequest;
+import com.frend.planit.domain.user.dto.response.SocialLoginResponse;
+import com.frend.planit.domain.user.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final UserService userService;
+
+    /**
+     * 소셜 로그인 (Google, Kakao, Naver)
+     */
+    @PostMapping("/social-login")
+    public ResponseEntity<SocialLoginResponse> socialLogin(
+            @RequestBody @Valid SocialLoginRequest request
+    ) {
+        SocialLoginResponse response = userService.loginOrRegister(request);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/backend/src/main/java/com/frend/planit/domain/user/controller/UserController.java
+++ b/backend/src/main/java/com/frend/planit/domain/user/controller/UserController.java
@@ -3,13 +3,11 @@ package com.frend.planit.domain.user.controller;
 import com.frend.planit.domain.user.dto.request.UserFirstInfoRequest;
 import com.frend.planit.domain.user.dto.response.UserMeResponse;
 import com.frend.planit.domain.user.service.UserService;
-import com.frend.planit.global.exception.ServiceException;
-import com.frend.planit.global.response.ErrorType;
-import com.frend.planit.global.security.JwtTokenProvider;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -17,24 +15,22 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+
 @RestController
 @RequestMapping("/api/v1/user")
 @RequiredArgsConstructor
 public class UserController {
 
     private final UserService userService;
-    private final JwtTokenProvider jwtTokenProvider;
 
     /**
      * 최초 로그인 시 사용자 추가 정보 입력
      */
     @PatchMapping("/me/first-info")
     public ResponseEntity<Void> updateFirstInfo(
-            HttpServletRequest request,
             @RequestBody @Valid UserFirstInfoRequest firstInfoRequest
     ) {
-        String token = resolveTokenFromHeader(request);
-        Long userId = jwtTokenProvider.getUserIdFromToken(token);
+        Long userId = getCurrentUserId();
         userService.updateFirstInfo(userId, firstInfoRequest);
         return ResponseEntity.noContent().build();
     }
@@ -52,18 +48,17 @@ public class UserController {
      * 현재 로그인한 유저 정보 조회
      */
     @GetMapping("/me")
-    public ResponseEntity<UserMeResponse> getMyInfo(HttpServletRequest request) {
-        String token = resolveTokenFromHeader(request);
-        Long userId = jwtTokenProvider.getUserIdFromToken(token);
+    public ResponseEntity<UserMeResponse> getMyInfo() {
+        Long userId = getCurrentUserId();
         UserMeResponse response = userService.getMyInfo(userId);
         return ResponseEntity.ok(response);
     }
 
-    private String resolveTokenFromHeader(HttpServletRequest request) {
-        String bearer = request.getHeader("Authorization");
-        if (bearer != null && bearer.startsWith("Bearer ")) {
-            return bearer.substring(7);
-        }
-        throw new ServiceException(ErrorType.UNAUTHORIZED);
+    /**
+     * SecurityContext에서 현재 로그인한 사용자 ID 추출
+     */
+    private Long getCurrentUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        return (Long) authentication.getPrincipal();
     }
 }

--- a/backend/src/main/java/com/frend/planit/domain/user/controller/UserController.java
+++ b/backend/src/main/java/com/frend/planit/domain/user/controller/UserController.java
@@ -6,8 +6,7 @@ import com.frend.planit.domain.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -28,9 +27,9 @@ public class UserController {
      */
     @PatchMapping("/me/first-info")
     public ResponseEntity<Void> updateFirstInfo(
+            @AuthenticationPrincipal Long userId,
             @RequestBody @Valid UserFirstInfoRequest firstInfoRequest
     ) {
-        Long userId = getCurrentUserId();
         userService.updateFirstInfo(userId, firstInfoRequest);
         return ResponseEntity.noContent().build();
     }
@@ -48,17 +47,8 @@ public class UserController {
      * 현재 로그인한 유저 정보 조회
      */
     @GetMapping("/me")
-    public ResponseEntity<UserMeResponse> getMyInfo() {
-        Long userId = getCurrentUserId();
+    public ResponseEntity<UserMeResponse> getMyInfo(@AuthenticationPrincipal Long userId) {
         UserMeResponse response = userService.getMyInfo(userId);
         return ResponseEntity.ok(response);
-    }
-
-    /**
-     * SecurityContext에서 현재 로그인한 사용자 ID 추출
-     */
-    private Long getCurrentUserId() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        return (Long) authentication.getPrincipal();
     }
 }

--- a/backend/src/main/java/com/frend/planit/domain/user/controller/UserController.java
+++ b/backend/src/main/java/com/frend/planit/domain/user/controller/UserController.java
@@ -1,8 +1,6 @@
 package com.frend.planit.domain.user.controller;
 
-import com.frend.planit.domain.user.dto.request.SocialLoginRequest;
 import com.frend.planit.domain.user.dto.request.UserFirstInfoRequest;
-import com.frend.planit.domain.user.dto.response.SocialLoginResponse;
 import com.frend.planit.domain.user.dto.response.UserMeResponse;
 import com.frend.planit.domain.user.service.UserService;
 import com.frend.planit.global.exception.ServiceException;
@@ -14,7 +12,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -27,16 +24,6 @@ public class UserController {
 
     private final UserService userService;
     private final JwtTokenProvider jwtTokenProvider;
-
-    /**
-     * 소셜 로그인 (Google, Kakao, Naver)
-     */
-    @PostMapping("/login")
-    public ResponseEntity<SocialLoginResponse> login(
-            @RequestBody @Valid SocialLoginRequest request) {
-        SocialLoginResponse response = userService.loginOrRegister(request);
-        return ResponseEntity.ok(response);
-    }
 
     /**
      * 최초 로그인 시 사용자 추가 정보 입력

--- a/backend/src/main/java/com/frend/planit/domain/user/mapper/UserMapper.java
+++ b/backend/src/main/java/com/frend/planit/domain/user/mapper/UserMapper.java
@@ -1,6 +1,6 @@
 package com.frend.planit.domain.user.mapper;
 
-import com.frend.planit.domain.user.dto.response.GoogleUserInfoResponse;
+import com.frend.planit.domain.auth.dto.response.GoogleUserInfoResponse;
 import com.frend.planit.domain.user.entity.User;
 import com.frend.planit.domain.user.enums.LoginType;
 import com.frend.planit.domain.user.enums.Role;

--- a/backend/src/main/java/com/frend/planit/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/frend/planit/domain/user/service/UserService.java
@@ -1,21 +1,14 @@
 package com.frend.planit.domain.user.service;
 
-import com.frend.planit.domain.user.client.OAuthClient;
-import com.frend.planit.domain.user.client.OAuthClientFactory;
-import com.frend.planit.domain.user.dto.request.SocialLoginRequest;
+import com.frend.planit.domain.auth.client.OAuthClientFactory;
 import com.frend.planit.domain.user.dto.request.UserFirstInfoRequest;
-import com.frend.planit.domain.user.dto.response.GoogleTokenResponse;
-import com.frend.planit.domain.user.dto.response.GoogleUserInfoResponse;
-import com.frend.planit.domain.user.dto.response.SocialLoginResponse;
 import com.frend.planit.domain.user.dto.response.UserMeResponse;
 import com.frend.planit.domain.user.entity.User;
 import com.frend.planit.domain.user.enums.UserStatus;
-import com.frend.planit.domain.user.mapper.UserMapper;
 import com.frend.planit.domain.user.repository.UserRepository;
 import com.frend.planit.global.exception.ServiceException;
 import com.frend.planit.global.response.ErrorType;
 import com.frend.planit.global.security.JwtTokenProvider;
-import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,32 +22,6 @@ public class UserService {
     private final UserRepository userRepository;
     private final JwtTokenProvider jwtTokenProvider;
 
-    /**
-     * 소셜 로그인 또는 회원가입
-     */
-    public SocialLoginResponse loginOrRegister(SocialLoginRequest request) {
-        OAuthClient client = oauthClientFactory.getClient(request.getSocialType());
-
-        GoogleTokenResponse tokenResponse = client.getAccessToken(request.getCode());
-        GoogleUserInfoResponse userInfo = client.getUserInfo(tokenResponse.getAccessToken());
-
-        User user = userRepository.findBySocialIdAndSocialType(userInfo.getSub(),
-                        client.getSocialType())
-                .orElseGet(() ->
-                        // 신규 유저: UNREGISTERED 상태로 저장
-                        userRepository.save(
-                                UserMapper.toEntity(userInfo, client.getSocialType())
-                        ));
-
-        // 마지막 로그인 시간 갱신
-        user.updateLastLoginAt(LocalDateTime.now());
-
-        // JWT 토큰 발급
-        String accessToken = jwtTokenProvider.createAccessToken(user.getId(), user.getRole());
-        String refreshToken = jwtTokenProvider.createRefreshToken(user.getId());
-
-        return new SocialLoginResponse(accessToken, refreshToken, user.getStatus());
-    }
 
     /**
      * 최초 로그인 시 추가 정보 등록

--- a/backend/src/main/java/com/frend/planit/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/frend/planit/domain/user/service/UserService.java
@@ -1,6 +1,5 @@
 package com.frend.planit.domain.user.service;
 
-import com.frend.planit.domain.auth.client.OAuthClientFactory;
 import com.frend.planit.domain.user.dto.request.UserFirstInfoRequest;
 import com.frend.planit.domain.user.dto.response.UserMeResponse;
 import com.frend.planit.domain.user.entity.User;
@@ -8,7 +7,6 @@ import com.frend.planit.domain.user.enums.UserStatus;
 import com.frend.planit.domain.user.repository.UserRepository;
 import com.frend.planit.global.exception.ServiceException;
 import com.frend.planit.global.response.ErrorType;
-import com.frend.planit.global.security.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,10 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class UserService {
 
-    private final OAuthClientFactory oauthClientFactory;
     private final UserRepository userRepository;
-    private final JwtTokenProvider jwtTokenProvider;
-
 
     /**
      * 최초 로그인 시 추가 정보 등록

--- a/backend/src/main/java/com/frend/planit/global/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/frend/planit/global/security/JwtAuthenticationFilter.java
@@ -5,8 +5,10 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -25,10 +27,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         if (token != null && jwtTokenProvider.validateToken(token)) {
             Long userId = jwtTokenProvider.getUserIdFromToken(token);
+            List<GrantedAuthority> authorities = jwtTokenProvider.getAuthorities(token);
 
             // userId만 담은 인증 객체 생성 -> 이후 @AuthenticationPrincipal 사용 가능.
             UsernamePasswordAuthenticationToken authentication =
-                    new UsernamePasswordAuthenticationToken(userId, null, null);
+                    new UsernamePasswordAuthenticationToken(userId, null, authorities);
 
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }

--- a/backend/src/main/java/com/frend/planit/global/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/frend/planit/global/security/JwtAuthenticationFilter.java
@@ -26,7 +26,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (token != null && jwtTokenProvider.validateToken(token)) {
             Long userId = jwtTokenProvider.getUserIdFromToken(token);
 
-            // userId만 담은 인증 객체 생성
+            // userId만 담은 인증 객체 생성 -> 이후 @AuthenticationPrincipal 사용 가능.
             UsernamePasswordAuthenticationToken authentication =
                     new UsernamePasswordAuthenticationToken(userId, null, null);
 
@@ -36,6 +36,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
     }
 
+    // 토큰 추출
     private String resolveToken(HttpServletRequest request) {
         String bearer = request.getHeader("Authorization");
         if (bearer != null && bearer.startsWith("Bearer ")) {

--- a/backend/src/main/java/com/frend/planit/global/security/JwtTokenProvider.java
+++ b/backend/src/main/java/com/frend/planit/global/security/JwtTokenProvider.java
@@ -5,8 +5,11 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import java.util.Date;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.jwt.JwtException;
 import org.springframework.stereotype.Component;
 
@@ -61,11 +64,7 @@ public class JwtTokenProvider {
 
     // 유저 ID 추출
     public Long getUserIdFromToken(String token) {
-        Claims claims = Jwts.parser()
-                .setSigningKey(secretKey.getBytes())
-                .parseClaimsJws(token)
-                .getBody();
-
+        Claims claims = parseClaims(token);
         return Long.valueOf(claims.getSubject());
     }
 
@@ -76,10 +75,21 @@ public class JwtTokenProvider {
 
     // refresh token 만료 임박시 재발급
     public Date getExpiration(String token) {
+        return parseClaims(token).getExpiration();
+    }
+
+    // 토큰 내 권한(Role) 정보를 Security 권한 객체로 변환
+    public List<GrantedAuthority> getAuthorities(String token) {
+        Claims claims = parseClaims(token);
+        String role = claims.get("role", String.class);
+        return List.of(new SimpleGrantedAuthority("ROLE_" + role));
+    }
+
+    // Claims 파싱 메서드 (공통화)
+    private Claims parseClaims(String token) {
         return Jwts.parser()
                 .setSigningKey(secretKey.getBytes())
                 .parseClaimsJws(token)
-                .getBody()
-                .getExpiration();
+                .getBody();
     }
 }

--- a/backend/src/main/java/com/frend/planit/global/security/JwtTokenProvider.java
+++ b/backend/src/main/java/com/frend/planit/global/security/JwtTokenProvider.java
@@ -68,4 +68,9 @@ public class JwtTokenProvider {
 
         return Long.valueOf(claims.getSubject());
     }
+
+    // refresh token 만료 시간 getter (Redis TTL 설정용)
+    public long getRefreshTokenExpirationMs() {
+        return refreshTokenExpiration;
+    }
 }

--- a/backend/src/main/java/com/frend/planit/global/security/JwtTokenProvider.java
+++ b/backend/src/main/java/com/frend/planit/global/security/JwtTokenProvider.java
@@ -73,4 +73,13 @@ public class JwtTokenProvider {
     public long getRefreshTokenExpirationMs() {
         return refreshTokenExpiration;
     }
+
+    // refresh token 만료 임박시 재발급
+    public Date getExpiration(String token) {
+        return Jwts.parser()
+                .setSigningKey(secretKey.getBytes())
+                .parseClaimsJws(token)
+                .getBody()
+                .getExpiration();
+    }
 }

--- a/backend/src/main/java/com/frend/planit/global/security/SecurityConfig.java
+++ b/backend/src/main/java/com/frend/planit/global/security/SecurityConfig.java
@@ -28,7 +28,7 @@ public class SecurityConfig {
                         .authenticationEntryPoint(authenticationEntryPoint)
                 )
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/v1/user/login").permitAll()
+                        .requestMatchers("/api/v1/auth/**").permitAll()
                         .requestMatchers("/api/v1/user/me/first-info").authenticated()
                         .anyRequest().permitAll()
                 )

--- a/backend/src/main/resources/application-test.yml
+++ b/backend/src/main/resources/application-test.yml
@@ -16,3 +16,16 @@ spring:
   sql:
     init:
       mode: never
+
+jwt:
+  secret: test-jwt-secret
+  access-token-expiration-ms: 3600000
+  refresh-token-expiration-ms: 604800000
+
+oauth2:
+  google:
+    client-id: test-client-id
+    client-secret: test-secret
+    redirect-uri: http://localhost:3000/oauth/callback/google
+    token-uri: https://oauth2.googleapis.com/token
+    user-info-uri: https://www.googleapis.com/oauth2/v1/userinfo

--- a/backend/src/test/java/com/frend/planit/domain/auth/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/frend/planit/domain/auth/controller/AuthControllerTest.java
@@ -70,7 +70,7 @@ class AuthControllerTest {
     void refreshAccessToken() throws Exception {
         // given
         TokenRefreshRequest request = new TokenRefreshRequest("valid-refresh-token");
-        TokenRefreshResponse response = new TokenRefreshResponse("new-access-token");
+        TokenRefreshResponse response = new TokenRefreshResponse("accessToken", "new-access-token");
 
         Mockito.when(authService.refreshAccessToken("valid-refresh-token"))
                 .thenReturn(response);

--- a/backend/src/test/java/com/frend/planit/domain/user/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/frend/planit/domain/user/controller/AuthControllerTest.java
@@ -1,0 +1,63 @@
+package com.frend.planit.domain.user.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.frend.planit.domain.user.client.GoogleOauthClient;
+import com.frend.planit.domain.user.dto.request.SocialLoginRequest;
+import com.frend.planit.domain.user.dto.response.SocialLoginResponse;
+import com.frend.planit.domain.user.enums.SocialType;
+import com.frend.planit.domain.user.enums.UserStatus;
+import com.frend.planit.domain.user.service.UserService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private UserService userService;
+
+    @MockBean
+    private GoogleOauthClient googleOauthClient;
+
+    @Test
+    @DisplayName("소셜 로그인 성공")
+    void socialLoginSuccess() throws Exception {
+        // given
+        SocialLoginRequest request = new SocialLoginRequest(SocialType.GOOGLE, "test-code");
+        SocialLoginResponse response = new SocialLoginResponse("access-token", "refresh-token",
+                UserStatus.ACTIVE);
+
+        Mockito.when(userService.loginOrRegister(any(SocialLoginRequest.class)))
+                .thenReturn(response);
+
+        // when & then
+        mockMvc.perform(post("/api/v1/auth/social-login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").value("access-token"))
+                .andExpect(jsonPath("$.refreshToken").value("refresh-token"))
+                .andExpect(jsonPath("$.status").value("ACTIVE"));
+    }
+}

--- a/backend/src/test/java/com/frend/planit/domain/user/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/frend/planit/domain/user/controller/AuthControllerTest.java
@@ -6,12 +6,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.frend.planit.domain.user.client.GoogleOauthClient;
-import com.frend.planit.domain.user.dto.request.SocialLoginRequest;
-import com.frend.planit.domain.user.dto.response.SocialLoginResponse;
+import com.frend.planit.domain.auth.client.GoogleOauthClient;
+import com.frend.planit.domain.auth.dto.request.SocialLoginRequest;
+import com.frend.planit.domain.auth.dto.response.SocialLoginResponse;
+import com.frend.planit.domain.auth.service.AuthService;
 import com.frend.planit.domain.user.enums.SocialType;
 import com.frend.planit.domain.user.enums.UserStatus;
-import com.frend.planit.domain.user.service.UserService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -35,7 +35,7 @@ class AuthControllerTest {
     private ObjectMapper objectMapper;
 
     @MockBean
-    private UserService userService;
+    private AuthService authService;
 
     @MockBean
     private GoogleOauthClient googleOauthClient;
@@ -48,7 +48,7 @@ class AuthControllerTest {
         SocialLoginResponse response = new SocialLoginResponse("access-token", "refresh-token",
                 UserStatus.ACTIVE);
 
-        Mockito.when(userService.loginOrRegister(any(SocialLoginRequest.class)))
+        Mockito.when(authService.loginOrRegister(any(SocialLoginRequest.class)))
                 .thenReturn(response);
 
         // when & then

--- a/backend/src/test/java/com/frend/planit/domain/user/controller/UserControllerTest.java
+++ b/backend/src/test/java/com/frend/planit/domain/user/controller/UserControllerTest.java
@@ -5,15 +5,12 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.frend.planit.domain.user.dto.request.SocialLoginRequest;
 import com.frend.planit.domain.user.dto.request.UserFirstInfoRequest;
-import com.frend.planit.domain.user.dto.response.SocialLoginResponse;
 import com.frend.planit.domain.user.dto.response.UserMeResponse;
 import com.frend.planit.domain.user.enums.LoginType;
 import com.frend.planit.domain.user.enums.Role;
@@ -51,26 +48,6 @@ class UserControllerTest {
     @MockBean
     private JwtTokenProvider jwtTokenProvider;
 
-    @Test
-    @DisplayName("소셜 로그인 성공")
-    void loginSuccess() throws Exception {
-        // given
-        SocialLoginRequest request = new SocialLoginRequest(SocialType.GOOGLE, "test-code");
-        SocialLoginResponse response = new SocialLoginResponse("access-token", "refresh-token",
-                UserStatus.ACTIVE);
-
-        Mockito.when(userService.loginOrRegister(any(SocialLoginRequest.class)))
-                .thenReturn(response);
-
-        // when & then
-        mockMvc.perform(post("/api/v1/user/login")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.accessToken").value("access-token"))
-                .andExpect(jsonPath("$.refreshToken").value("refresh-token"))
-                .andExpect(jsonPath("$.status").value("ACTIVE"));
-    }
 
     @Test
     @DisplayName("닉네임 중복 확인 성공")


### PR DESCRIPTION
## 🔘 Part

- [x] BE
- [ ] Infra
  <br/>

## 🔎 PR Type

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 주요 코드 리팩토링(성능 최적화 등)
- [ ] 간단 코드 리팩토링(주석, 코드 컨벤션, 오타 수정 등)
- [ ] 기타 (기타 사항 기입)
  <br/>

## 🔧 작업 내용 상세 작성
- [ feature/U-02 #62](https://github.com/prgrms-web-devcourse-final-project/WEB3_4_Fr-End_BE/issues/62)

-  logout 기능 : logout 요청한 클라이언트의 accesstoken 값 불러와서 delete -> 로그아웃 (accesstoken 값 유효한 30분 동안은 기능 사용가능 .. 실무에서도 이렇게 사용한다네요?)
-  jwtAuthenticationFilter 로 token 처리하는 과정 개입하여 userid, role 부분 포함하여 accesstoken으로 발급
- 발급된 토큰 @AuthenticationPrincipal 에너테이션으로 userid 불러올 수 있음.
- 추후 admin 기능 구현 시 @PreAuthorize("hasRole('ADMIN')") 에너테이션으로 role_admin 확인 가능.
  <br/>
## ✔️ PR Checklist

- [ ] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?

- [ ] 테스트 코드 작성 / 단위 테스트 or 통합 테스트 진행 하셨나요?
  <br/>
