### PR TITLE
Refactor/S-01 #105 : ScheduleService 검증 로직 리팩토링 및 여행지 정렬 로직 추가

### DIFF
--- a/backend/src/main/java/com/frend/planit/domain/calendar/schedule/controller/ScheduleController.java
+++ b/backend/src/main/java/com/frend/planit/domain/calendar/schedule/controller/ScheduleController.java
@@ -22,12 +22,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @Tag(name = "Schedule Controller", description = "여행 일정 컨트롤러")
-@RequestMapping("/api/v1/calendars/{calendarId}/schedule/{scheduleId}")
+@RequestMapping("/api/v1/calendars/{calendarId}/schedules")
 public class ScheduleController {
 
     private final ScheduleService scheduleService;
 
-    @GetMapping
+    @GetMapping("/{scheduleId}")
     @SecurityRequirement(name = "bearerAuth")
     @Operation(summary = "여행 일정 조회")
     @ResponseStatus(HttpStatus.OK)
@@ -44,13 +44,12 @@ public class ScheduleController {
     @ResponseStatus(HttpStatus.CREATED)
     public ScheduleResponse createSchedule(
             @PathVariable Long calendarId,
-            @PathVariable Long scheduleId,
             @Valid @RequestBody ScheduleRequest scheduleRequest
     ) {
-        return scheduleService.createSchedule(calendarId, scheduleId, scheduleRequest);
+        return scheduleService.createSchedule(calendarId, scheduleRequest);
     }
 
-    @PatchMapping
+    @PatchMapping("/{scheduleId}")
     @SecurityRequirement(name = "bearerAuth")
     @Operation(summary = "여행 일정 수정")
     @ResponseStatus(HttpStatus.OK)
@@ -62,7 +61,7 @@ public class ScheduleController {
         return scheduleService.modifySchedule(calendarId, scheduleId, scheduleRequest);
     }
 
-    @DeleteMapping
+    @DeleteMapping("/{scheduleId}")
     @SecurityRequirement(name = "bearerAuth")
     @Operation(summary = "여행 일정 삭제")
     @ResponseStatus(HttpStatus.OK)

--- a/backend/src/main/java/com/frend/planit/domain/calendar/schedule/day/entity/ScheduleDayEntity.java
+++ b/backend/src/main/java/com/frend/planit/domain/calendar/schedule/day/entity/ScheduleDayEntity.java
@@ -67,9 +67,4 @@ public class ScheduleDayEntity extends BaseTime {
     public void setSchedule(ScheduleEntity schedule) {
         this.schedule = schedule;
     }
-
-    // Test Code에서 사용하기 위한 setter
-    public void setId(Long id) {
-        this.id = id;
-    }
 }

--- a/backend/src/main/java/com/frend/planit/domain/calendar/schedule/entity/ScheduleEntity.java
+++ b/backend/src/main/java/com/frend/planit/domain/calendar/schedule/entity/ScheduleEntity.java
@@ -68,8 +68,7 @@ public class ScheduleEntity {
                 .startDate(scheduleRequest.getStartDate())
                 .endDate(scheduleRequest.getEndDate())
                 .note(scheduleRequest.getNote())
-                .alertTime(scheduleRequest.getAlertTime() != null ? scheduleRequest.getAlertTime()
-                        : null)
+                .alertTime(scheduleRequest.getAlertTime())
                 .build();
 
         // ScheduleDay 자동 생성
@@ -86,11 +85,6 @@ public class ScheduleEntity {
     public void addScheduleDay(ScheduleDayEntity scheduleDay) {
         this.scheduleDayList.add(scheduleDay);
         scheduleDay.setSchedule(this);
-    }
-
-    // Test Code에서 사용하기 위한 setter
-    public void setId(Long id) {
-        this.id = id;
     }
 
     public void updateSchedule(ScheduleRequest scheduleRequest) {

--- a/backend/src/main/java/com/frend/planit/domain/calendar/schedule/service/ScheduleService.java
+++ b/backend/src/main/java/com/frend/planit/domain/calendar/schedule/service/ScheduleService.java
@@ -22,38 +22,26 @@ public class ScheduleService {
     // 여행 일정 조회
     @Transactional(readOnly = true)
     public ScheduleResponse getSchedules(Long calendarId, Long scheduleId) {
-        // 스케줄 존재 여부 확인
-        ScheduleEntity scheduleEntity = scheduleRepository.findById(scheduleId)
-                .orElseThrow(() -> new ServiceException(ErrorType.SCHEDULE_NOT_FOUND));
-
-        // scheduleEntity의 calendarId와 요청한 calendarId가 일치하는지 확인
-        if (!scheduleEntity.getCalendar().getId().equals(calendarId)) {
-            throw new ServiceException(ErrorType.CALENDAR_NOT_FOUND);
-        }
+        // 여행 일정 존재 여부 확인
+        ScheduleEntity scheduleEntity = findScheduleById(calendarId, scheduleId);
 
         return ScheduleResponse.from(scheduleEntity);
     }
 
     // 여행 일정 생성
     @Transactional
-    public ScheduleResponse createSchedule(Long calendarId, Long scheduleId,
-            ScheduleRequest scheduleRequest) {
-        // 스케줄 존재 여부 확인
-        scheduleRepository.findById(scheduleId)
-                .orElseThrow(() -> new ServiceException(ErrorType.SCHEDULE_NOT_FOUND));
-
-        // 캘린더 존재 여부 확인
+    public ScheduleResponse createSchedule(
+            Long calendarId,
+            ScheduleRequest scheduleRequest
+    ) {
+        // calendar 존재 여부 확인 및 조회
         CalendarEntity calendar = calendarRepository.findById(calendarId)
                 .orElseThrow(() -> new ServiceException(ErrorType.CALENDAR_NOT_FOUND));
 
         // scheduleEntity 생성
         ScheduleEntity scheduleEntity = ScheduleEntity.of(calendar, scheduleRequest);
 
-        // scheduleEntity의 calendarId와 요청한 calendarId가 일치하는지 확인
-        if (!scheduleEntity.getCalendar().getId().equals(calendarId)) {
-            throw new ServiceException(ErrorType.CALENDAR_NOT_FOUND);
-        }
-
+        // scheduleEntity 저장
         ScheduleEntity createdScheduleEntity = scheduleRepository.save(scheduleEntity);
 
         return ScheduleResponse.from(createdScheduleEntity);
@@ -63,18 +51,8 @@ public class ScheduleService {
     @Transactional
     public ScheduleResponse modifySchedule(Long calendarId, Long scheduleId,
             ScheduleRequest scheduleRequest) {
-        // 스케줄 존재 여부 확인
-        ScheduleEntity scheduleEntity = scheduleRepository.findById(scheduleId)
-                .orElseThrow(() -> new ServiceException(ErrorType.SCHEDULE_NOT_FOUND));
-
-        // 캘린더 존재 여부 확인
-        CalendarEntity calendar = calendarRepository.findById(calendarId)
-                .orElseThrow(() -> new ServiceException(ErrorType.CALENDAR_NOT_FOUND));
-
-        // scheduleEntity의 calendarId와 요청한 calendarId가 일치하는지 확인
-        if (!scheduleEntity.getCalendar().getId().equals(calendarId)) {
-            throw new ServiceException(ErrorType.CALENDAR_NOT_FOUND);
-        }
+        // 여행 일정 존재 여부 확인
+        ScheduleEntity scheduleEntity = findScheduleById(calendarId, scheduleId);
 
         // scheduleEntity 수정
         scheduleEntity.updateSchedule(scheduleRequest);
@@ -85,22 +63,26 @@ public class ScheduleService {
     // 여행 일정 삭제
     @Transactional
     public ScheduleResponse deleteSchedule(Long calendarId, Long scheduleId) {
-        // 스케줄 존재 여부 확인
-        ScheduleEntity scheduleEntity = scheduleRepository.findById(scheduleId)
-                .orElseThrow(() -> new ServiceException(ErrorType.SCHEDULE_NOT_FOUND));
-
-        // 캘린더 존재 여부 확인
-        CalendarEntity calendar = calendarRepository.findById(calendarId)
-                .orElseThrow(() -> new ServiceException(ErrorType.CALENDAR_NOT_FOUND));
-
-        // scheduleEntity의 calendarId와 요청한 calendarId가 일치하는지 확인
-        if (!scheduleEntity.getCalendar().getId().equals(calendarId)) {
-            throw new ServiceException(ErrorType.CALENDAR_NOT_FOUND);
-        }
+        // 여행 일정 존재 여부 확인
+        ScheduleEntity scheduleEntity = findScheduleById(calendarId, scheduleId);
 
         // scheduleEntity 삭제
         scheduleRepository.delete(scheduleEntity);
 
         return ScheduleResponse.from(scheduleEntity);
+    }
+
+    // 여행 일정 존재 여부 확인
+    public ScheduleEntity findScheduleById(Long scheduleId, Long calendarId) {
+
+        // 스케줄 존재 여부 확인
+        ScheduleEntity scheduleEntity = scheduleRepository.findById(scheduleId)
+                .orElseThrow(() -> new ServiceException(ErrorType.SCHEDULE_NOT_FOUND));
+
+        // scheduleEntity의 calendarId와 요청한 calendarId가 일치하는지 확인
+        if (!scheduleEntity.getCalendar().getId().equals(calendarId)) {
+            throw new ServiceException(ErrorType.CALENDAR_NOT_FOUND);
+        }
+        return scheduleEntity;
     }
 }

--- a/backend/src/main/java/com/frend/planit/domain/calendar/schedule/travel/dto/response/DailyTravelResponse.java
+++ b/backend/src/main/java/com/frend/planit/domain/calendar/schedule/travel/dto/response/DailyTravelResponse.java
@@ -1,6 +1,8 @@
 package com.frend.planit.domain.calendar.schedule.travel.dto.response;
 
+import com.frend.planit.domain.calendar.schedule.travel.entity.TravelEntity;
 import java.time.LocalDate;
+import java.util.Comparator;
 import java.util.List;
 import lombok.Getter;
 
@@ -20,7 +22,15 @@ public class DailyTravelResponse {
     }
 
     public static DailyTravelResponse of(Long scheduleDayId, LocalDate date,
-            List<TravelResponse> travelList) {
-        return new DailyTravelResponse(scheduleDayId, date, travelList);
+            List<TravelEntity> travelEntities) {
+
+        // 여행 일정 별 시간/분에 따른 정렬
+        List<TravelResponse> sortedTravels = travelEntities.stream()
+                .sorted(Comparator.comparingInt(TravelEntity::getVisitHour)
+                        .thenComparingInt(TravelEntity::getVisitMinute))
+                .map(TravelResponse::from)
+                .toList();
+
+        return new DailyTravelResponse(scheduleDayId, date, sortedTravels);
     }
 }

--- a/backend/src/main/java/com/frend/planit/domain/calendar/schedule/travel/entity/TravelEntity.java
+++ b/backend/src/main/java/com/frend/planit/domain/calendar/schedule/travel/entity/TravelEntity.java
@@ -89,9 +89,4 @@ public class TravelEntity extends BaseTime {
         this.visitHour = travelRequest.getHour();
         this.visitMinute = travelRequest.getMinute();
     }
-
-    // Test Code에서 사용하기 위한 setter
-    public void setId(Long id) {
-        this.id = id;
-    }
 }

--- a/backend/src/test/java/com/frend/planit/domain/calendar/schedule/travel/service/TravelServiceTest.java
+++ b/backend/src/test/java/com/frend/planit/domain/calendar/schedule/travel/service/TravelServiceTest.java
@@ -36,6 +36,7 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -84,14 +85,14 @@ public class TravelServiceTest {
 
         // 스케줄 생성 (3일짜리)
         schedule = ScheduleEntity.of(calendar, scheduleRequest);
-        schedule.setId(1L);
+        ReflectionTestUtils.setField(schedule, "id", 1L);
 
         // 4월 6일에 해당하는 ScheduleDay 찾기
         scheduleDay = schedule.getScheduleDayList().stream()
                 .filter(day -> day.getDate().equals(LocalDate.of(2025, 4, 6)))
                 .findFirst()
                 .orElseThrow();
-        scheduleDay.setId(10L);
+        ReflectionTestUtils.setField(scheduleDay, "id", 10L);
 
         // 요청 DTO
         request = TravelRequest.builder()
@@ -107,7 +108,7 @@ public class TravelServiceTest {
 
         // 여행지 생성 (scheduleDay 필요함)
         travel = TravelEntity.of(request, scheduleDay);
-        travel.setId(100L);
+        ReflectionTestUtils.setField(travel, "id", 100L);
     }
 
     @Test
@@ -123,7 +124,7 @@ public class TravelServiceTest {
         // 그룹핑 유틸리티는 실제 로직과 상관없이 mock 처리
         List<DailyTravelResponse> dummyResponse = List.of(
                 DailyTravelResponse.of(scheduleDay.getId(), scheduleDay.getDate(),
-                        List.of(TravelResponse.from(travel)))
+                        List.of(travel))
         );
         mockStatic(TravelGroupingUtils.class).when(() ->
                 TravelGroupingUtils.groupTravelsByDate(anyList())
@@ -227,7 +228,7 @@ public class TravelServiceTest {
                 .build();
 
         ScheduleEntity wrongSchedule = ScheduleEntity.of(wrongCalendar, wrongScheduleRequest);
-        wrongSchedule.setId(2L);
+        ReflectionTestUtils.setField(wrongSchedule, "id", 2L);
 
         scheduleDay.setSchedule(wrongSchedule);
 
@@ -275,7 +276,7 @@ public class TravelServiceTest {
                 .build();
 
         ScheduleEntity wrongSchedule = ScheduleEntity.of(wrongCalendar, wrongScheduleRequest);
-        wrongSchedule.setId(2L);
+        ReflectionTestUtils.setField(wrongSchedule, "id", 2L);
 
         // 기존 scheduleDay는 여전히 잘못된 스케줄에 연결됨
         scheduleDay.setSchedule(wrongSchedule);


### PR DESCRIPTION
## 🔘 Part

- [x] BE
- [ ] Infra
  <br/>

## 🔎 PR Type

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 주요 코드 리팩토링(성능 최적화 등)
- [ ] 간단 코드 리팩토링(주석, 코드 컨벤션, 오타 수정 등)
- [ ] 기타 (기타 사항 기입)
  <br/>

## 🔧 작업 내용 상세 작성
- #105 

- ScheduleService 내 중복되는 일정 및 캘린더 검증 로직을 별도 메서드로 분리
- scheduleRepository.findById()와 calendarRepository.findById()를 각각 호출하던 방식에서 → scheduleId, calendarId를 함께 검증하는 메서드로 개선
- DailyTravelResponse 내 여행지 리스트(travels)를 hour, minute 기준 오름차순으로 정렬하여 반환하도록 수정
  <br/>

## ✔️ PR Checklist

- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?

- [x] 테스트 코드 작성 / 단위 테스트 or 통합 테스트 진행 하셨나요?
  <br/>
