### PR TITLE
Refactor/MB-02 : 유저 연동 이슈 수정

### DIFF
--- a/backend/src/main/java/com/frend/planit/domain/mateboard/application/controller/MateApplicationController.java
+++ b/backend/src/main/java/com/frend/planit/domain/mateboard/application/controller/MateApplicationController.java
@@ -1,7 +1,6 @@
 package com.frend.planit.domain.mateboard.application.controller;
 
 import com.frend.planit.domain.mateboard.application.service.MateApplicationService;
-import com.frend.planit.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -32,24 +31,24 @@ public class MateApplicationController {
      * 메이트 모집 게시글에 신청합니다.
      *
      * @param mateId 신청할 게시글 ID
-     * @param user   현재 로그인한 사용자
+     * @param userId 현재 로그인한 사용자
      */
     @PostMapping("/{mateId}")
     @ResponseStatus(HttpStatus.CREATED)
-    public void applyToMate(@PathVariable Long mateId, @AuthenticationPrincipal User user) {
-        mateApplicationService.applyToMate(user.getId(), mateId);
+    public void applyToMate(@PathVariable Long mateId, @AuthenticationPrincipal Long userId) {
+        mateApplicationService.applyToMate(userId, mateId);
     }
 
     /**
      * 메이트 모집 게시글에 대한 신청을 취소합니다.
      *
      * @param mateId 신청을 취소할 게시글 ID
-     * @param user   현재 로그인한 사용자 (신청자 본인)
+     * @param userId 현재 로그인한 사용자 (신청자 본인)
      */
     @DeleteMapping("/{mateId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void cancelApplication(@PathVariable Long mateId, @AuthenticationPrincipal User user) {
-        mateApplicationService.cancelApplication(user.getId(), mateId);
+    public void cancelApplication(@PathVariable Long mateId, @AuthenticationPrincipal Long userId) {
+        mateApplicationService.cancelApplication(userId, mateId);
     }
 
     /**
@@ -57,15 +56,15 @@ public class MateApplicationController {
      *
      * @param mateId      게시글 ID
      * @param applicantId 수락할 신청자 ID
-     * @param user        현재 로그인한 사용자 (게시글 작성자)
+     * @param userId      현재 로그인한 사용자 (게시글 작성자)
      */
     @PutMapping("/{mateId}/accept/{applicantId}")
     @ResponseStatus(HttpStatus.OK)
     public void acceptApplication(
             @PathVariable Long mateId,
             @PathVariable Long applicantId,
-            @AuthenticationPrincipal User user) {
-        mateApplicationService.acceptApplication(mateId, applicantId, user.getId());
+            @AuthenticationPrincipal Long userId) {
+        mateApplicationService.acceptApplication(mateId, applicantId, userId);
     }
 
     /**
@@ -73,14 +72,14 @@ public class MateApplicationController {
      *
      * @param mateId      게시글 ID
      * @param applicantId 거절할 신청자 ID
-     * @param user        현재 로그인한 사용자 (게시글 작성자)
+     * @param userId      현재 로그인한 사용자 (게시글 작성자)
      */
     @PutMapping("/{mateId}/reject/{applicantId}")
     @ResponseStatus(HttpStatus.OK)
     public void rejectApplication(
             @PathVariable Long mateId,
             @PathVariable Long applicantId,
-            @AuthenticationPrincipal User user) {
-        mateApplicationService.rejectApplication(mateId, applicantId, user.getId());
+            @AuthenticationPrincipal Long userId) {
+        mateApplicationService.rejectApplication(mateId, applicantId, userId);
     }
 }

--- a/backend/src/main/java/com/frend/planit/domain/mateboard/application/entity/MateApplication.java
+++ b/backend/src/main/java/com/frend/planit/domain/mateboard/application/entity/MateApplication.java
@@ -3,6 +3,7 @@ package com.frend.planit.domain.mateboard.application.entity;
 import com.frend.planit.domain.mateboard.post.entity.Mate;
 import com.frend.planit.domain.user.entity.User;
 import com.frend.planit.global.base.BaseTime;
+import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -11,6 +12,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -38,6 +40,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Table(name = "mate_application")
+@AttributeOverride(name = "id", column = @Column(name = "mate_application_id"))
 public class MateApplication extends BaseTime {
 
     // 지원자
@@ -47,7 +51,7 @@ public class MateApplication extends BaseTime {
 
     // 지원한 게시글
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "mate_id", nullable = false)
+    @JoinColumn(name = "mate_post_id", nullable = false)
     private Mate mate;
 
     // 신청 상태 (대기 / 수락 / 거절)

--- a/backend/src/main/java/com/frend/planit/domain/mateboard/comment/controller/MateCommentController.java
+++ b/backend/src/main/java/com/frend/planit/domain/mateboard/comment/controller/MateCommentController.java
@@ -3,7 +3,6 @@ package com.frend.planit.domain.mateboard.comment.controller;
 import com.frend.planit.domain.mateboard.comment.dto.request.MateCommentRequestDto;
 import com.frend.planit.domain.mateboard.comment.dto.response.MateCommentResponseDto;
 import com.frend.planit.domain.mateboard.comment.service.MateCommentService;
-import com.frend.planit.domain.user.entity.User;
 import com.frend.planit.global.response.PageResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -50,8 +49,8 @@ public class MateCommentController {
     public Long createComment(
             @RequestBody @Valid MateCommentRequestDto mateCommentRequestDto,
             @PathVariable Long mateId,
-            @AuthenticationPrincipal User loginUser) {// TODO: 로그인 기능 연동 필요
-        return mateCommentService.createComment(loginUser.getId(), mateId, mateCommentRequestDto);
+            @AuthenticationPrincipal Long userId) {
+        return mateCommentService.createComment(userId, mateId, mateCommentRequestDto);
     }
 
     /**
@@ -92,20 +91,21 @@ public class MateCommentController {
     @ResponseStatus(HttpStatus.OK)
     public MateCommentResponseDto updateComment(@PathVariable Long id,
             @RequestBody @Valid MateCommentRequestDto mateCommentRequestDto,
-            @AuthenticationPrincipal User loginUser) {
-        return mateCommentService.updateComment(id, mateCommentRequestDto, loginUser.getId());
+            @AuthenticationPrincipal Long userId) {
+        return mateCommentService.updateComment(id, mateCommentRequestDto, userId);
     }
 
     /**
      * 특정 댓글을 삭제합니다.
      *
-     * @param id 삭제할 댓글 ID
-     * @return 삭제된 댓글 ID
+     * @param id
+     * @param userId
+     * @return
      */
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public MateCommentResponseDto deleteComment(@PathVariable Long id,
-            @AuthenticationPrincipal User loginUser) {
-        return mateCommentService.deleteComment(id, loginUser.getId());
+            @AuthenticationPrincipal Long userId) {
+        return mateCommentService.deleteComment(id, userId);
     }
 }

--- a/backend/src/main/java/com/frend/planit/domain/mateboard/comment/entity/MateComment.java
+++ b/backend/src/main/java/com/frend/planit/domain/mateboard/comment/entity/MateComment.java
@@ -3,11 +3,13 @@ package com.frend.planit.domain.mateboard.comment.entity;
 import com.frend.planit.domain.mateboard.post.entity.Mate;
 import com.frend.planit.domain.user.entity.User;
 import com.frend.planit.global.base.BaseTime;
+import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -21,13 +23,15 @@ import lombok.Setter;
 @Getter
 @Setter
 @Entity
+@Table(name = "mate_comment")
+@AttributeOverride(name = "id", column = @Column(name = "mate_comment_id"))
 public class MateComment extends BaseTime {
 
     /**
      * 메이트 모집 게시글 ID
      */
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "mate_id", nullable = false)
+    @JoinColumn(name = "mate_post_id", nullable = false)
     private Mate mate;
 
     /**

--- a/backend/src/main/java/com/frend/planit/domain/mateboard/post/controller/MateController.java
+++ b/backend/src/main/java/com/frend/planit/domain/mateboard/post/controller/MateController.java
@@ -3,7 +3,6 @@ package com.frend.planit.domain.mateboard.post.controller;
 import com.frend.planit.domain.mateboard.post.dto.request.MateRequestDto;
 import com.frend.planit.domain.mateboard.post.dto.response.MateResponseDto;
 import com.frend.planit.domain.mateboard.post.service.MateService;
-import com.frend.planit.domain.user.entity.User;
 import com.frend.planit.global.response.PageResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -43,15 +42,15 @@ public class MateController {
     /**
      * 메이트 모집 게시글을 생성합니다.
      *
-     * @param user           로그인한 사용자 정보 (@AuthenticationPrincipal로 주입)
+     * @param userId         로그인한 사용자 정보 (@AuthenticationPrincipal로 주입)
      * @param mateRequestDto 사용자가 입력한 게시글 정보
      * @return mateId 생성된 게시글 ID
      */
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public ResponseEntity<?> createMate(@AuthenticationPrincipal User user,
+    public ResponseEntity<?> createMate(@AuthenticationPrincipal Long userId,
             @RequestBody @Valid MateRequestDto mateRequestDto) {
-        Long mateId = mateService.createMate(user.getId(), mateRequestDto);
+        Long mateId = mateService.createMate(userId, mateRequestDto);
         return ResponseEntity.status(HttpStatus.CREATED).body(mateId);
     }
 
@@ -89,27 +88,27 @@ public class MateController {
      *
      * @param id             수정할 게시글 ID
      * @param mateRequestDto 수정할 게시글의 요청 본문(제목, 내용, 날짜, 지역, 성별 등)
-     * @param user           로그인한 사용자 정보 (@AuthenticationPrincipal로 주입)
+     * @param userId         로그인한 사용자 정보 (@AuthenticationPrincipal로 주입)
      * @return 수정된 게시글 응답 DTO
      */
     @PutMapping("/{id}")
     @ResponseStatus(HttpStatus.OK)
     public MateResponseDto updateMate(@PathVariable Long id,
             @RequestBody @Valid MateRequestDto mateRequestDto,
-            @AuthenticationPrincipal User user) {
-        return mateService.updateMate(id, mateRequestDto, user.getId());
+            @AuthenticationPrincipal Long userId) {
+        return mateService.updateMate(id, mateRequestDto, userId);
     }
 
     /**
      * 메이트 모집 게시글을 삭제합니다.
      *
-     * @param id   삭제할 게시글 ID
-     * @param user 로그인한 사용자 정보 (@AuthenticationPrincipal로 주입)
+     * @param id     삭제할 게시글 ID
+     * @param userId 로그인한 사용자 정보 (@AuthenticationPrincipal로 주입)
      * @return 삭제한 게시글 응답 DTO
      */
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void deleteMate(@PathVariable Long id, @AuthenticationPrincipal User user) {
-        mateService.deleteMate(id, user.getId());
+    public void deleteMate(@PathVariable Long id, @AuthenticationPrincipal Long userId) {
+        mateService.deleteMate(id, userId);
     }
 }

--- a/backend/src/main/java/com/frend/planit/domain/mateboard/post/entity/Mate.java
+++ b/backend/src/main/java/com/frend/planit/domain/mateboard/post/entity/Mate.java
@@ -4,6 +4,7 @@ import com.frend.planit.domain.mateboard.application.entity.MateApplication;
 import com.frend.planit.domain.mateboard.application.entity.MateApplicationStatus;
 import com.frend.planit.domain.user.entity.User;
 import com.frend.planit.global.base.BaseTime;
+import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -13,6 +14,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -30,6 +32,8 @@ import lombok.Setter;
 @Getter
 @Setter
 @Entity
+@Table(name = "mate")
+@AttributeOverride(name = "id", column = @Column(name = "mate_post_id"))
 public class Mate extends BaseTime {
 
     /**
@@ -40,11 +44,11 @@ public class Mate extends BaseTime {
      * 사용자 ID
      */
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "writer_id", nullable = false)
+    @JoinColumn(name = "user_id", nullable = false)
     private User writer;
 
     /**
-     * 사용자 프로필 이미지 (TODO: User 엔티티와 연관 관계 매핑 예정)
+     * 사용자 프로필 이미지
      */
 
     /**

--- a/backend/src/test/java/com/frend/planit/domain/mateboard/post/controller/MateControllerTest.java
+++ b/backend/src/test/java/com/frend/planit/domain/mateboard/post/controller/MateControllerTest.java
@@ -210,6 +210,4 @@ public class MateControllerTest {
         mockMvc.perform(delete("/api/v1/mate-board/posts/{id}", postId))
                 .andExpect(status().isNoContent());
     }
-
-
 }

--- a/backend/src/test/java/com/frend/planit/domain/mateboard/post/controller/MateControllerTest.java
+++ b/backend/src/test/java/com/frend/planit/domain/mateboard/post/controller/MateControllerTest.java
@@ -43,31 +43,32 @@ public class MateControllerTest {
 
     @Autowired
     private ObjectMapper objectMapper;
-
+    
     @DisplayName("게시글 생성 API 테스트")
     @Test
     @WithMockCustomUser(id = 1L, username = "mockuser")
     void createMate_success() throws Exception {
-        // given
+        System.out.println("===== 테스트 실행됨 =====");
+
         MateRequestDto requestDto = MateRequestDto.builder()
                 .title("테스트 제목입니다")
                 .content("테스트 내용입니다. 20자 이상 입력해야 해서 울릉도 동남쪽 뱃길따라 이백리 외로운 섬하나 새들의 고향.")
                 .recruitCount(3)
                 .travelRegion(TravelRegion.ALL)
-                .travelStartDate(LocalDate.of(2025, 05, 01))
-                .travelEndDate(LocalDate.of(2025, 05, 30))
+                .travelStartDate(LocalDate.of(2025, 5, 1))
+                .travelEndDate(LocalDate.of(2025, 5, 30))
                 .mateGender(MateGender.NO_PREFERENCE)
                 .build();
 
         String json = objectMapper.writeValueAsString(requestDto);
 
-        // when & then
         mockMvc.perform(post("/api/v1/mate-board/posts")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(json))
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$").isNumber()); // 생성된 게시글 ID나 내용
+                .andExpect(jsonPath("$").isNumber());
     }
+
 
     @Test
     @DisplayName("메이트 게시글 단건 조회 성공")

--- a/backend/src/test/java/com/frend/planit/testsecurity/WithMockCustomUserSecurityContextFactory.java
+++ b/backend/src/test/java/com/frend/planit/testsecurity/WithMockCustomUserSecurityContextFactory.java
@@ -1,7 +1,6 @@
 package com.frend.planit.testsecurity;
 
 
-import com.frend.planit.domain.user.entity.User;
 import java.util.List;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContext;
@@ -15,10 +14,10 @@ public class WithMockCustomUserSecurityContextFactory implements
     public SecurityContext createSecurityContext(WithMockCustomUser annotation) {
         SecurityContext context = SecurityContextHolder.createEmptyContext();
 
-        User user = UserTestFactory.createMockUser(annotation.id(), annotation.username());
+        Long userId = annotation.id();
 
         UsernamePasswordAuthenticationToken auth =
-                new UsernamePasswordAuthenticationToken(user, "password", List.of());
+                new UsernamePasswordAuthenticationToken(userId, null, List.of());
 
         context.setAuthentication(auth);
         return context;


### PR DESCRIPTION
Refactor/MB-02 : 유저 연동 이슈 수정
<br/>

## 🔘 Part

- [x] BE
- [ ] Infra
  <br/>

## 🔎 PR Type

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 주요 코드 리팩토링(성능 최적화 등)
- [ ] 간단 코드 리팩토링(주석, 코드 컨벤션, 오타 수정 등)
- [ ] 기타 (기타 사항 기입)
  <br/>

## 🔧 작업 내용 상세 작성
- [Refactor/MB-02 #115]
- 
모든 컨트롤러에서 @AuthenticationPrincipal User user → @AuthenticationPrincipal Long userId로 변경
user.getId() 사용 부분 제거
서비스 단에서는 필요 시 userRepository.findById(userId)로 직접 User 조회
JWT 필터에서 userId(Long)를 principal로 넣고 있으므로 전체 흐름에 문제 없음
  <br/>
## ✔️ PR Checklist

- [ ] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?

- [ ] 테스트 코드 작성 / 단위 테스트 or 통합 테스트 진행 하셨나요?
  <br/>
