### PR TITLE
Refactor/S-01 #127 : ScheduleDay 날짜 오름차순 정렬 및 travelCount 오류 수정

### DIFF
--- a/backend/src/main/java/com/frend/planit/domain/calendar/schedule/repository/ScheduleRepository.java
+++ b/backend/src/main/java/com/frend/planit/domain/calendar/schedule/repository/ScheduleRepository.java
@@ -2,11 +2,18 @@ package com.frend.planit.domain.calendar.schedule.repository;
 
 import com.frend.planit.domain.calendar.schedule.entity.ScheduleEntity;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface ScheduleRepository extends JpaRepository<ScheduleEntity, Long> {
+
+    // 스케줄 존재 여부 확인
+    @Query("SELECT s FROM ScheduleEntity s WHERE s.id = :scheduleId AND s.calendar.id = :calendarId")
+    Optional<ScheduleEntity> findByIdAndCalendarId(
+            @Param("calendarId") Long calendarId,
+            @Param("scheduleId") Long scheduleId);
 
     // 특정 유저의 모든 일정
     @Query("SELECT s FROM ScheduleEntity s WHERE s.calendar.user.id = :userId")

--- a/backend/src/main/java/com/frend/planit/domain/calendar/schedule/repository/ScheduleRepository.java
+++ b/backend/src/main/java/com/frend/planit/domain/calendar/schedule/repository/ScheduleRepository.java
@@ -9,12 +9,6 @@ import org.springframework.data.repository.query.Param;
 public interface ScheduleRepository extends JpaRepository<ScheduleEntity, Long> {
 
     // 특정 유저의 모든 일정
-    @Query("""
-                SELECT s
-                FROM ScheduleEntity s
-                JOIN s.calendar c
-                JOIN c.user u
-                WHERE u.id = :userId
-            """)
+    @Query("SELECT s FROM ScheduleEntity s WHERE s.calendar.user.id = :userId")
     List<ScheduleEntity> findAllByUserId(@Param("userId") Long userId);
 }

--- a/backend/src/main/java/com/frend/planit/domain/calendar/schedule/service/ScheduleService.java
+++ b/backend/src/main/java/com/frend/planit/domain/calendar/schedule/service/ScheduleService.java
@@ -76,13 +76,7 @@ public class ScheduleService {
     public ScheduleEntity findScheduleById(Long scheduleId, Long calendarId) {
 
         // 스케줄 존재 여부 확인
-        ScheduleEntity scheduleEntity = scheduleRepository.findById(scheduleId)
+        return scheduleRepository.findByIdAndCalendarId(scheduleId, calendarId)
                 .orElseThrow(() -> new ServiceException(ErrorType.SCHEDULE_NOT_FOUND));
-
-        // scheduleEntity의 calendarId와 요청한 calendarId가 일치하는지 확인
-        if (!scheduleEntity.getCalendar().getId().equals(calendarId)) {
-            throw new ServiceException(ErrorType.CALENDAR_NOT_FOUND);
-        }
-        return scheduleEntity;
     }
 }

--- a/backend/src/main/java/com/frend/planit/domain/calendar/schedule/travel/dto/request/TravelRequest.java
+++ b/backend/src/main/java/com/frend/planit/domain/calendar/schedule/travel/dto/request/TravelRequest.java
@@ -1,10 +1,9 @@
 package com.frend.planit.domain.calendar.schedule.travel.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -41,13 +40,19 @@ public class TravelRequest {
     @JsonProperty("y")
     private Double lng;
 
-    @NotNull
-    @Min(0)
-    @Max(23)
-    private int hour;
+    @NotBlank
+    @Pattern(regexp = "^(0[0-9]|1[0-9]|2[0-3])$")
+    private String hour;
 
-    @NotNull
-    @Min(0)
-    @Max(59)
-    private int minute;
+    @NotBlank
+    @Pattern(regexp = "^[0-5][0-9]$")
+    private String minute;
+
+    public int getIntHour() {
+        return Integer.parseInt(hour);
+    }
+
+    public int getIntMinute() {
+        return Integer.parseInt(minute);
+    }
 }

--- a/backend/src/main/java/com/frend/planit/domain/calendar/schedule/travel/entity/TravelEntity.java
+++ b/backend/src/main/java/com/frend/planit/domain/calendar/schedule/travel/entity/TravelEntity.java
@@ -65,8 +65,8 @@ public class TravelEntity extends BaseTime {
                 .category(request.getCategory())
                 .lat(request.getLat())
                 .lng(request.getLng())
-                .visitHour(request.getHour())
-                .visitMinute(request.getMinute())
+                .visitHour(request.getIntHour())
+                .visitMinute(request.getIntMinute())
                 .build();
 
         // 편의 메서드로 연관관계 설정
@@ -86,7 +86,7 @@ public class TravelEntity extends BaseTime {
         this.category = travelRequest.getCategory();
         this.lat = travelRequest.getLat();
         this.lng = travelRequest.getLng();
-        this.visitHour = travelRequest.getHour();
-        this.visitMinute = travelRequest.getMinute();
+        this.visitHour = travelRequest.getIntHour();
+        this.visitMinute = travelRequest.getIntMinute();
     }
 }

--- a/backend/src/main/java/com/frend/planit/domain/calendar/schedule/travel/service/TravelService.java
+++ b/backend/src/main/java/com/frend/planit/domain/calendar/schedule/travel/service/TravelService.java
@@ -33,8 +33,6 @@ public class TravelService {
 
         // 행선지 조회
         List<TravelEntity> travels = travelRepository.findAllByScheduleId(scheduleId);
-
-        // 스케줄에 속한 행선지가 없는 경우 예외 처리
         if (travels.isEmpty()) {
             throw new ServiceException(ErrorType.TRAVEL_NOT_FOUND);
         }

--- a/backend/src/main/java/com/frend/planit/domain/calendar/schedule/travel/travelUtils/TravelGroupingUtils.java
+++ b/backend/src/main/java/com/frend/planit/domain/calendar/schedule/travel/travelUtils/TravelGroupingUtils.java
@@ -25,8 +25,7 @@ public class TravelGroupingUtils {
 
         // 그룹핑된 날짜별 여행 리스트로 DailyTravelResponse 변환
         return travelsByDate.entrySet().stream()
-                .sorted(Map.Entry.<LocalDate, List<TravelEntity>>comparingByKey()
-                        .reversed()) // 내림차순 정렬
+                .sorted(Map.Entry.<LocalDate, List<TravelEntity>>comparingByKey()) // 오름차순 정렬
                 .map(entry -> {
                     LocalDate date = entry.getKey();
                     List<TravelEntity> travelList = entry.getValue();

--- a/backend/src/main/java/com/frend/planit/domain/calendar/schedule/travel/travelUtils/TravelGroupingUtils.java
+++ b/backend/src/main/java/com/frend/planit/domain/calendar/schedule/travel/travelUtils/TravelGroupingUtils.java
@@ -4,6 +4,7 @@ import com.frend.planit.domain.calendar.schedule.travel.dto.response.DailyTravel
 import com.frend.planit.domain.calendar.schedule.travel.dto.response.TravelResponse;
 import com.frend.planit.domain.calendar.schedule.travel.entity.TravelEntity;
 import java.time.LocalDate;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -24,6 +25,8 @@ public class TravelGroupingUtils {
 
         // 그룹핑된 날짜별 여행 리스트로 DailyTravelResponse 변환
         return travelsByDate.entrySet().stream()
+                .sorted(Map.Entry.<LocalDate, List<TravelEntity>>comparingByKey()
+                        .reversed()) // 내림차순 정렬
                 .map(entry -> {
                     LocalDate date = entry.getKey();
                     List<TravelEntity> travelList = entry.getValue();
@@ -32,7 +35,10 @@ public class TravelGroupingUtils {
                     Long scheduleDayId = travelList.isEmpty() ? null
                             : travelList.get(0).getScheduleDay().getId();
 
+                    // 시간 기준으로 정렬된 TravelResponse 리스트
                     List<TravelResponse> travelResponses = travelList.stream()
+                            .sorted(Comparator.comparingInt(TravelEntity::getVisitHour)
+                                    .thenComparingInt(TravelEntity::getVisitMinute))
                             .map(TravelResponse::from)
                             .collect(Collectors.toList());
 


### PR DESCRIPTION
## 🔘 Part

- [x] BE
- [ ] Infra
  <br/>

## 🔎 PR Type

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 주요 코드 리팩토링(성능 최적화 등)
- [ ] 간단 코드 리팩토링(주석, 코드 컨벤션, 오타 수정 등)
- [ ] 기타 (기타 사항 기입)
  <br/>

## 🔧 작업 내용 상세 작성
- #127 

- ScheduleDayResponse의 날짜 정렬 기준을 내림차순 → 오름차순으로 수정
- travelCount 값이 항상 1로 고정되던 문제를 수정하고, travelList.size() 기반으로 정확히 반영
- 정렬 및 travelCount 계산은 TravelGroupingUtils.groupTravelsByDate() 로직 내부에서 처리
  <br/>
## ✔️ PR Checklist

- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?

- [x] 테스트 코드 작성 / 단위 테스트 or 통합 테스트 진행 하셨나요?
  <br/>
