### PR TITLE
Feat/U-06 # 133 : 로컬 로그인시 socialid = null 로 직접 주입

### DIFF
--- a/backend/src/main/java/com/frend/planit/domain/auth/dto/request/LocalRegisterRequest.java
+++ b/backend/src/main/java/com/frend/planit/domain/auth/dto/request/LocalRegisterRequest.java
@@ -38,6 +38,7 @@ public class LocalRegisterRequest {
     private boolean mailingType = false;
 
     private String socialId = null;
+    private String socialType = null;
 
 }
 

--- a/backend/src/main/java/com/frend/planit/domain/auth/dto/request/LocalRegisterRequest.java
+++ b/backend/src/main/java/com/frend/planit/domain/auth/dto/request/LocalRegisterRequest.java
@@ -36,5 +36,8 @@ public class LocalRegisterRequest {
     private LocalDate birthDate;
 
     private boolean mailingType = false;
+
+    private String socialId = null;
+
 }
 

--- a/backend/src/test/java/com/frend/planit/domain/auth/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/frend/planit/domain/auth/controller/AuthControllerTest.java
@@ -98,7 +98,8 @@ class AuthControllerTest {
                 "https://www.example.com/image.jpg",
                 Gender.FEMALE,
                 LocalDate.of(2001, 9, 9),
-                false
+                false,
+                null
         );
         LocalRegisterResponse response = new LocalRegisterResponse(1L, "ricky50", "Mark",
                 "william51@hotmail.com");

--- a/backend/src/test/java/com/frend/planit/domain/auth/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/frend/planit/domain/auth/controller/AuthControllerTest.java
@@ -99,6 +99,7 @@ class AuthControllerTest {
                 Gender.FEMALE,
                 LocalDate.of(2001, 9, 9),
                 false,
+                null,
                 null
         );
         LocalRegisterResponse response = new LocalRegisterResponse(1L, "ricky50", "Mark",


### PR DESCRIPTION
## 🔘 Part

- [x] BE
- [ ] Infra
  <br/>

## 🔎 PR Type

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 주요 코드 리팩토링(성능 최적화 등)
- [ ] 간단 코드 리팩토링(주석, 코드 컨벤션, 오타 수정 등)
- [ ] 기타 (기타 사항 기입)
  <br/>

## 🔧 작업 내용 상세 작성
- [Feat/U-06 # 133](https://github.com/prgrms-web-devcourse-final-project/WEB3_4_Fr-End_BE/issues/133)

- 회원가입시 requestDto에 socialid 값을 null 로 처리하는 기능이 없었음.
- socialid와 socialtype은 unique 타입이므로 
  <br/>
## ✔️ PR Checklist

- [ ] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?

- [ ] 테스트 코드 작성 / 단위 테스트 or 통합 테스트 진행 하셨나요?
  <br/>
