### PR TITLE
[Refactor] MB-01 #130 : 게시글 id 값, 댓글 id 값 반환

### DIFF
--- a/backend/src/main/java/com/frend/planit/domain/mateboard/comment/dto/response/MateCommentResponseDto.java
+++ b/backend/src/main/java/com/frend/planit/domain/mateboard/comment/dto/response/MateCommentResponseDto.java
@@ -20,7 +20,7 @@ public class MateCommentResponseDto {
 
     private final Long matePostId;
 
-    private final Long userId;
+    private final Long authorId;
 
     private final String nickname;
 

--- a/backend/src/main/java/com/frend/planit/domain/mateboard/comment/dto/response/MateCommentResponseDto.java
+++ b/backend/src/main/java/com/frend/planit/domain/mateboard/comment/dto/response/MateCommentResponseDto.java
@@ -16,7 +16,7 @@ import lombok.Getter;
 @Builder
 public class MateCommentResponseDto {
 
-    private final Long commentId;
+    private final Long mateCommentId;
 
     private final Long matePostId;
 

--- a/backend/src/main/java/com/frend/planit/domain/mateboard/comment/dto/response/MateCommentResponseDto.java
+++ b/backend/src/main/java/com/frend/planit/domain/mateboard/comment/dto/response/MateCommentResponseDto.java
@@ -16,6 +16,8 @@ import lombok.Getter;
 @Builder
 public class MateCommentResponseDto {
 
+    private final Long commentId;
+
     private final Long matePostId;
 
     private final Long userId;

--- a/backend/src/main/java/com/frend/planit/domain/mateboard/comment/mapper/MateCommentMapper.java
+++ b/backend/src/main/java/com/frend/planit/domain/mateboard/comment/mapper/MateCommentMapper.java
@@ -16,7 +16,7 @@ public class MateCommentMapper {
 
     public static MateCommentResponseDto toResponseDto(MateComment comment) {
         return MateCommentResponseDto.builder()
-                .commentId(comment.getId())
+                .mateCommentId(comment.getId())
                 .matePostId(comment.getMate().getId())
                 .authorId(comment.getUser().getId())
                 .nickname(comment.getUser().getNickname())

--- a/backend/src/main/java/com/frend/planit/domain/mateboard/comment/mapper/MateCommentMapper.java
+++ b/backend/src/main/java/com/frend/planit/domain/mateboard/comment/mapper/MateCommentMapper.java
@@ -16,6 +16,7 @@ public class MateCommentMapper {
 
     public static MateCommentResponseDto toResponseDto(MateComment comment) {
         return MateCommentResponseDto.builder()
+                .commentId(comment.getId())
                 .matePostId(comment.getMate().getId())
                 .userId(comment.getUser().getId())
                 .nickname(comment.getUser().getNickname())

--- a/backend/src/main/java/com/frend/planit/domain/mateboard/comment/mapper/MateCommentMapper.java
+++ b/backend/src/main/java/com/frend/planit/domain/mateboard/comment/mapper/MateCommentMapper.java
@@ -18,7 +18,7 @@ public class MateCommentMapper {
         return MateCommentResponseDto.builder()
                 .commentId(comment.getId())
                 .matePostId(comment.getMate().getId())
-                .userId(comment.getUser().getId())
+                .authorId(comment.getUser().getId())
                 .nickname(comment.getUser().getNickname())
                 .profileImageUrl(comment.getUser().getProfileImageUrl())
                 .content(comment.getContent())

--- a/backend/src/main/java/com/frend/planit/domain/mateboard/post/dto/response/MateResponseDto.java
+++ b/backend/src/main/java/com/frend/planit/domain/mateboard/post/dto/response/MateResponseDto.java
@@ -22,6 +22,7 @@ import lombok.Getter;
 public class MateResponseDto {
 
     private final Long matePostId;
+    private final Long authorId;
     private final String title;
     private final String content;
     private final TravelRegion travelRegion;
@@ -39,13 +40,14 @@ public class MateResponseDto {
     private LocalDateTime createdAt;
 
     @QueryProjection
-    public MateResponseDto(Long matePostId, String title, String content,
+    public MateResponseDto(Long matePostId, Long authorId, String title, String content,
             TravelRegion travelRegion, LocalDate travelStartDate, LocalDate travelEndDate,
             RecruitmentStatus recruitmentStatus, MateGender mateGender,
             int recruitCount, int appliedCount, String imageUrl,
             String nickname, String bio, String profileImage, Gender authorGender,
             LocalDateTime createdAt) {
         this.matePostId = matePostId;
+        this.authorId = authorId;
         this.title = title;
         this.content = content;
         this.travelRegion = travelRegion;

--- a/backend/src/main/java/com/frend/planit/domain/mateboard/post/dto/response/MateResponseDto.java
+++ b/backend/src/main/java/com/frend/planit/domain/mateboard/post/dto/response/MateResponseDto.java
@@ -21,7 +21,7 @@ import lombok.Getter;
 @Getter
 public class MateResponseDto {
 
-    private final Long id;
+    private final Long matePostId;
     private final String title;
     private final String content;
     private final TravelRegion travelRegion;
@@ -39,13 +39,13 @@ public class MateResponseDto {
     private LocalDateTime createdAt;
 
     @QueryProjection
-    public MateResponseDto(Long id, String title, String content,
+    public MateResponseDto(Long matePostId, String title, String content,
             TravelRegion travelRegion, LocalDate travelStartDate, LocalDate travelEndDate,
             RecruitmentStatus recruitmentStatus, MateGender mateGender,
             int recruitCount, int appliedCount, String imageUrl,
             String nickname, String bio, String profileImage, Gender authorGender,
             LocalDateTime createdAt) {
-        this.id = id;
+        this.matePostId = matePostId;
         this.title = title;
         this.content = content;
         this.travelRegion = travelRegion;

--- a/backend/src/main/java/com/frend/planit/domain/mateboard/post/mapper/MateMapper.java
+++ b/backend/src/main/java/com/frend/planit/domain/mateboard/post/mapper/MateMapper.java
@@ -24,6 +24,7 @@ public class MateMapper {
 
         return MateResponseDto.builder()
                 .matePostId(mate.getId())
+                .authorId(mate.getWriter().getId())
                 .nickname(mate.getWriter().getNickname())
                 .profileImage(mate.getWriter().getProfileImageUrl())
                 .authorGender(mate.getWriter().getGender())

--- a/backend/src/main/java/com/frend/planit/domain/mateboard/post/mapper/MateMapper.java
+++ b/backend/src/main/java/com/frend/planit/domain/mateboard/post/mapper/MateMapper.java
@@ -23,7 +23,7 @@ public class MateMapper {
     public static MateResponseDto toResponseDto(Mate mate, String imageUrl) {
 
         return MateResponseDto.builder()
-                .id(mate.getId())
+                .matePostId(mate.getId())
                 .nickname(mate.getWriter().getNickname())
                 .profileImage(mate.getWriter().getProfileImageUrl())
                 .authorGender(mate.getWriter().getGender())

--- a/backend/src/main/java/com/frend/planit/domain/mateboard/post/repository/MateQueryRepositoryImpl.java
+++ b/backend/src/main/java/com/frend/planit/domain/mateboard/post/repository/MateQueryRepositoryImpl.java
@@ -76,6 +76,7 @@ public class MateQueryRepositoryImpl implements MateQueryRepository {
         var results = queryFactory
                 .select(new QMateResponseDto(
                         mate.id,
+                        mate.writer.id,
                         mate.title,
                         mate.content,
                         mate.travelRegion,


### PR DESCRIPTION
[Refactor] MB-01 #130 : 게시글 id 값, 댓글 id 값 반환
<br/>

## 🔘 Part

- [x] BE
- [ ] Infra
  <br/>

## 🔎 PR Type

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 주요 코드 리팩토링(성능 최적화 등)
- [ ] 간단 코드 리팩토링(주석, 코드 컨벤션, 오타 수정 등)
- [ ] 기타 (기타 사항 기입)
  <br/>

## 🔧 작업 내용 상세 작성
- [레포 이름 #이슈번호](이슈 주소)

- [x] 댓글 전체 조회시 작성자 아이디값 반환
- [x] 게시글 상세 조회시 작성자 아이디값 반환
- [x] 댓글 전체 조회시 commentId값 반환
- [x] 게시글 상세 조회시 postId값 반환

<br/>
## ✔️ PR Checklist

- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?

- [ ] 테스트 코드 작성 / 단위 테스트 or 통합 테스트 진행 하셨나요?
  <br/>
