### PR TITLE
Refactor/S-01 #154 : 스케줄 전체 조회 기능 추가

### DIFF
--- a/backend/src/main/java/com/frend/planit/domain/calendar/schedule/controller/ScheduleController.java
+++ b/backend/src/main/java/com/frend/planit/domain/calendar/schedule/controller/ScheduleController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -28,14 +29,23 @@ public class ScheduleController {
 
     private final ScheduleService scheduleService;
 
-    @GetMapping("/{scheduleId}")
-    @Operation(summary = "여행 일정 조회")
+    @GetMapping
+    @Operation(summary = "전체 여행 일정 조회")
     @ResponseStatus(HttpStatus.OK)
-    public ScheduleResponse getSchedules(
+    public List<ScheduleResponse> getAllSchedules(
+            @PathVariable Long calendarId
+    ) {
+        return scheduleService.getAllSchedules(calendarId);
+    }
+
+    @GetMapping("/{scheduleId}")
+    @Operation(summary = "단일 여행 일정 조회")
+    @ResponseStatus(HttpStatus.OK)
+    public ScheduleResponse getSchedule(
             @PathVariable Long calendarId,
             @PathVariable Long scheduleId
     ) {
-        return scheduleService.getSchedules(calendarId, scheduleId);
+        return scheduleService.getSchedule(calendarId, scheduleId);
     }
 
     @PostMapping

--- a/backend/src/main/java/com/frend/planit/domain/calendar/schedule/dto/response/ScheduleResponse.java
+++ b/backend/src/main/java/com/frend/planit/domain/calendar/schedule/dto/response/ScheduleResponse.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.frend.planit.domain.calendar.schedule.entity.ScheduleEntity;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -31,5 +32,11 @@ public class ScheduleResponse {
                 .alertTime(scheduleEntity.getAlertTime())
                 .note(scheduleEntity.getNote())
                 .build();
+    }
+
+    public static List<ScheduleResponse> fronList(List<ScheduleEntity> scheduleEntities) {
+        return scheduleEntities.stream()
+                .map(ScheduleResponse::from)
+                .toList();
     }
 }

--- a/backend/src/main/java/com/frend/planit/domain/calendar/schedule/repository/ScheduleRepository.java
+++ b/backend/src/main/java/com/frend/planit/domain/calendar/schedule/repository/ScheduleRepository.java
@@ -9,7 +9,11 @@ import org.springframework.data.repository.query.Param;
 
 public interface ScheduleRepository extends JpaRepository<ScheduleEntity, Long> {
 
-    // 스케줄 존재 여부 확인
+    // 전체 스케줄 조회
+    @Query("SELECT s FROM ScheduleEntity s WHERE s.calendar.id = :calendarId")
+    List<ScheduleEntity> findAllByCalendarId(@Param("calendarId") Long calendarId);
+
+    // 전체 스케줄 조회
     @Query("SELECT s FROM ScheduleEntity s WHERE s.id = :scheduleId AND s.calendar.id = :calendarId")
     Optional<ScheduleEntity> findByIdAndCalendarId(
             @Param("calendarId") Long calendarId,

--- a/backend/src/main/java/com/frend/planit/domain/calendar/schedule/service/ScheduleService.java
+++ b/backend/src/main/java/com/frend/planit/domain/calendar/schedule/service/ScheduleService.java
@@ -8,6 +8,7 @@ import com.frend.planit.domain.calendar.schedule.entity.ScheduleEntity;
 import com.frend.planit.domain.calendar.schedule.repository.ScheduleRepository;
 import com.frend.planit.global.exception.ServiceException;
 import com.frend.planit.global.response.ErrorType;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,9 +20,18 @@ public class ScheduleService {
     private final ScheduleRepository scheduleRepository;
     private final CalendarRepository calendarRepository;
 
-    // 여행 일정 조회
+    // 전체 여행 일정 조회(readOnly = true)
+    public List<ScheduleResponse> getAllSchedules(Long calendarId) {
+        // 여행 일정 존재 여부 확인
+        List<ScheduleEntity> scheduleEntities = scheduleRepository.findAllByCalendarId(calendarId);
+
+        return ScheduleResponse.fronList(scheduleEntities);
+
+    }
+
+    // 단일 여행 일정 조회
     @Transactional(readOnly = true)
-    public ScheduleResponse getSchedules(Long calendarId, Long scheduleId) {
+    public ScheduleResponse getSchedule(Long calendarId, Long scheduleId) {
         // 여행 일정 존재 여부 확인
         ScheduleEntity scheduleEntity = findScheduleById(calendarId, scheduleId);
 


### PR DESCRIPTION
## 🔘 Part

- [x] BE
- [ ] Infra
  <br/>

## 🔎 PR Type

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 주요 코드 리팩토링(성능 최적화 등)
- [ ] 간단 코드 리팩토링(주석, 코드 컨벤션, 오타 수정 등)
- [ ] 기타 (기타 사항 기입)
  <br/>

## 🔧 작업 내용 상세 작성
- #154 

- ScheduleController에 전체 조회 API 엔드포인트 구현

- ScheduleService에 getAllSchedules(Long calendarId) 메서드 추가 및 응답 타입 변경

- ScheduleRepository에 findAllByCalendarId(Long calendarId) 메서드 추가

- ScheduleResponse에서 다건 변환을 위한 List 생성 메서드 구현
  <br/>
## ✔️ PR Checklist

- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?

- [x] 테스트 코드 작성 / 단위 테스트 or 통합 테스트 진행 하셨나요?
  <br/>
