### PR TITLE
Refactor/S-01 #156 : ScheduleController 보안 강화 및 색상 응답 추가 리팩토링

### DIFF
--- a/backend/src/main/java/com/frend/planit/domain/calendar/schedule/controller/ScheduleController.java
+++ b/backend/src/main/java/com/frend/planit/domain/calendar/schedule/controller/ScheduleController.java
@@ -10,6 +10,7 @@ import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -33,9 +34,10 @@ public class ScheduleController {
     @Operation(summary = "전체 여행 일정 조회")
     @ResponseStatus(HttpStatus.OK)
     public List<ScheduleResponse> getAllSchedules(
-            @PathVariable Long calendarId
+            @PathVariable Long calendarId,
+            @AuthenticationPrincipal Long userId
     ) {
-        return scheduleService.getAllSchedules(calendarId);
+        return scheduleService.getAllSchedules(calendarId, userId);
     }
 
     @GetMapping("/{scheduleId}")
@@ -43,9 +45,10 @@ public class ScheduleController {
     @ResponseStatus(HttpStatus.OK)
     public ScheduleResponse getSchedule(
             @PathVariable Long calendarId,
-            @PathVariable Long scheduleId
+            @PathVariable Long scheduleId,
+            @AuthenticationPrincipal Long userId
     ) {
-        return scheduleService.getSchedule(calendarId, scheduleId);
+        return scheduleService.getSchedule(calendarId, scheduleId, userId);
     }
 
     @PostMapping
@@ -53,9 +56,10 @@ public class ScheduleController {
     @ResponseStatus(HttpStatus.CREATED)
     public ScheduleResponse createSchedule(
             @PathVariable Long calendarId,
-            @Valid @RequestBody ScheduleRequest scheduleRequest
+            @Valid @RequestBody ScheduleRequest scheduleRequest,
+            @AuthenticationPrincipal Long userId
     ) {
-        return scheduleService.createSchedule(calendarId, scheduleRequest);
+        return scheduleService.createSchedule(calendarId, scheduleRequest, userId);
     }
 
     @PatchMapping("/{scheduleId}")
@@ -64,9 +68,10 @@ public class ScheduleController {
     public ScheduleResponse modifySchedule(
             @PathVariable Long calendarId,
             @PathVariable Long scheduleId,
-            @Valid @RequestBody ScheduleRequest scheduleRequest
+            @Valid @RequestBody ScheduleRequest scheduleRequest,
+            @AuthenticationPrincipal Long userId
     ) {
-        return scheduleService.modifySchedule(calendarId, scheduleId, scheduleRequest);
+        return scheduleService.modifySchedule(calendarId, scheduleId, scheduleRequest, userId);
     }
 
     @DeleteMapping("/{scheduleId}")
@@ -74,8 +79,9 @@ public class ScheduleController {
     @ResponseStatus(HttpStatus.OK)
     public ScheduleResponse deleteSchedule(
             @PathVariable Long calendarId,
-            @PathVariable Long scheduleId
+            @PathVariable Long scheduleId,
+            @AuthenticationPrincipal Long userId
     ) {
-        return scheduleService.deleteSchedule(calendarId, scheduleId);
+        return scheduleService.deleteSchedule(calendarId, scheduleId, userId);
     }
 }

--- a/backend/src/main/java/com/frend/planit/domain/calendar/schedule/day/entity/ScheduleDayEntity.java
+++ b/backend/src/main/java/com/frend/planit/domain/calendar/schedule/day/entity/ScheduleDayEntity.java
@@ -7,9 +7,6 @@ import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
@@ -30,11 +27,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "scheduleDay")
 public class ScheduleDayEntity extends BaseTime {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "schedule_day_id", nullable = false)
-    private Long id;
 
     @Column(name = "date", nullable = false)
     private LocalDate date;

--- a/backend/src/main/java/com/frend/planit/domain/calendar/schedule/dto/response/ScheduleResponse.java
+++ b/backend/src/main/java/com/frend/planit/domain/calendar/schedule/dto/response/ScheduleResponse.java
@@ -23,6 +23,9 @@ public class ScheduleResponse {
     private LocalTime alertTime;
     private String note;
 
+    @JsonProperty("label_color")
+    private String labelColor;
+
     public static ScheduleResponse from(ScheduleEntity scheduleEntity) {
         return ScheduleResponse.builder()
                 .id(scheduleEntity.getId())
@@ -31,6 +34,7 @@ public class ScheduleResponse {
                 .endDate(scheduleEntity.getEndDate())
                 .alertTime(scheduleEntity.getAlertTime())
                 .note(scheduleEntity.getNote())
+                .labelColor(scheduleEntity.getCalendar().getLabelColor())
                 .build();
     }
 

--- a/backend/src/main/java/com/frend/planit/domain/calendar/schedule/travel/dto/request/TravelRequest.java
+++ b/backend/src/main/java/com/frend/planit/domain/calendar/schedule/travel/dto/request/TravelRequest.java
@@ -48,11 +48,11 @@ public class TravelRequest {
     @Pattern(regexp = "^[0-5][0-9]$")
     private String minute;
 
-    public int getIntHour() {
+    public int parseIntHour() {
         return Integer.parseInt(hour);
     }
 
-    public int getIntMinute() {
+    public int parseIntMinute() {
         return Integer.parseInt(minute);
     }
 }

--- a/backend/src/main/java/com/frend/planit/domain/calendar/schedule/travel/entity/TravelEntity.java
+++ b/backend/src/main/java/com/frend/planit/domain/calendar/schedule/travel/entity/TravelEntity.java
@@ -57,8 +57,8 @@ public class TravelEntity extends BaseTime {
                 .category(request.getCategory())
                 .lat(request.getLat())
                 .lng(request.getLng())
-                .visitHour(request.getIntHour())
-                .visitMinute(request.getIntMinute())
+                .visitHour(request.parseIntHour())
+                .visitMinute(request.parseIntMinute())
                 .build();
 
         // 편의 메서드로 연관관계 설정
@@ -78,7 +78,7 @@ public class TravelEntity extends BaseTime {
         this.category = travelRequest.getCategory();
         this.lat = travelRequest.getLat();
         this.lng = travelRequest.getLng();
-        this.visitHour = travelRequest.getIntHour();
-        this.visitMinute = travelRequest.getIntMinute();
+        this.visitHour = travelRequest.parseIntHour();
+        this.visitMinute = travelRequest.parseIntMinute();
     }
 }

--- a/backend/src/test/java/com/frend/planit/domain/calendar/schedule/controller/ScheduleControllerTest.java
+++ b/backend/src/test/java/com/frend/planit/domain/calendar/schedule/controller/ScheduleControllerTest.java
@@ -92,6 +92,7 @@ public class ScheduleControllerTest {
                         .endDate(request1.getEndDate())
                         .alertTime(request1.getAlertTime())
                         .note(request1.getNote())
+                        .labelColor("#3b82f6")
                         .build(),
                 ScheduleResponse.builder()
                         .id(2L)
@@ -100,6 +101,7 @@ public class ScheduleControllerTest {
                         .endDate(request2.getEndDate())
                         .alertTime(request2.getAlertTime())
                         .note(request2.getNote())
+                        .labelColor("#ffcc00")
                         .build());
 
         // 단일 조회용 응답
@@ -156,7 +158,8 @@ public class ScheduleControllerTest {
                 .andExpect(jsonPath("$.startDate").value("2025-06-01"))
                 .andExpect(jsonPath("$.endDate").value("2025-06-03"))
                 .andExpect(jsonPath("$.alertTime").value("08:00:00"))
-                .andExpect(jsonPath("$.note").value("여행은 역시 먹방"));
+                .andExpect(jsonPath("$.note").value("여행은 역시 먹방"))
+                .andExpect(jsonPath("$.label_color").value("#3b82f6"));
 
         verify(scheduleService, times(1)).getSchedule(calendarId, scheduleId, userId);
     }


### PR DESCRIPTION
## 🔘 Part

- [x] BE
- [ ] Infra
  <br/>

## 🔎 PR Type

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 주요 코드 리팩토링(성능 최적화 등)
- [ ] 간단 코드 리팩토링(주석, 코드 컨벤션, 오타 수정 등)
- [ ] 기타 (기타 사항 기입)
  <br/>

## 🔧 작업 내용 상세 작성
- #156 

- ScheduleController의 전체 API에서 @AuthenticationPrincipal을 통해 사용자 인증 후, 해당 유저가 요청한 캘린더/일정의 소유자인지 검증하는 로직 추가
- CalendarEntity에 설정된 색상 코드(labelColor)가 일정 응답에 포함되지 않아 UI 렌더링에 어려움이 있었음 → ScheduleResponse에 labelColor 필드 추가 및 매핑 로직 구현
  <br/>
## ✔️ PR Checklist

- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?

- [x] 테스트 코드 작성 / 단위 테스트 or 통합 테스트 진행 하셨나요?
  <br/>
