### PR TITLE
Refactor/S-02 #165 : 스케줄 blockColor null 반환 버그 수정 및 리팩토링

### DIFF
--- a/backend/src/main/java/com/frend/planit/domain/calendar/schedule/entity/ScheduleEntity.java
+++ b/backend/src/main/java/com/frend/planit/domain/calendar/schedule/entity/ScheduleEntity.java
@@ -63,6 +63,7 @@ public class ScheduleEntity extends BaseTime {
                 .scheduleTitle(scheduleRequest.getScheduleTitle())
                 .startDate(scheduleRequest.getStartDate())
                 .endDate(scheduleRequest.getEndDate())
+                .blockColor(scheduleRequest.getBlockColor())
                 .note(scheduleRequest.getNote())
                 .alertTime(scheduleRequest.getAlertTime())
                 .build();
@@ -87,6 +88,7 @@ public class ScheduleEntity extends BaseTime {
         this.scheduleTitle = scheduleRequest.getScheduleTitle();
         this.startDate = scheduleRequest.getStartDate();
         this.endDate = scheduleRequest.getEndDate();
+        this.blockColor = scheduleRequest.getBlockColor();
         this.note = scheduleRequest.getNote();
         this.alertTime = scheduleRequest.getAlertTime();
 

--- a/backend/src/main/java/com/frend/planit/global/config/DataInitializer.java
+++ b/backend/src/main/java/com/frend/planit/global/config/DataInitializer.java
@@ -100,6 +100,7 @@ public class DataInitializer implements ApplicationRunner {
                     .scheduleTitle("테스트 일정 제목")
                     .startDate(LocalDate.now())
                     .endDate(LocalDate.now().plusDays(2))
+                    .blockColor("#FF5733")
                     .note("테스트 일정 노트")
                     .alertTime(LocalTime.now())
                     .build();


### PR DESCRIPTION
## 🔘 Part

- [x] BE
- [ ] Infra
  <br/>

## 🔎 PR Type

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 주요 코드 리팩토링(성능 최적화 등)
- [ ] 간단 코드 리팩토링(주석, 코드 컨벤션, 오타 수정 등)
- [ ] 기타 (기타 사항 기입)
  <br/>

## 🔧 작업 내용 상세 작성
- #165 

- ScheduleEntity.of, updateSchedule 메서드 내 blockColor 관련 로직 수정
- DataInitializer 내 테스트 데이터 초기화 시 blockColor 누락되지 않도록 수정
- Response에 스케줄 블럭 색상(blockColor) 값이 정상적으로 포함되도록 개선
  <br/>
## ✔️ PR Checklist

- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?

- [x] 테스트 코드 작성 / 단위 테스트 or 통합 테스트 진행 하셨나요?
  <br/>
